### PR TITLE
fix: subgraph queries responses

### DIFF
--- a/service/src/graph_node.rs
+++ b/service/src/graph_node.rs
@@ -31,10 +31,15 @@ impl GraphNodeInstance {
             .body(data.clone())
             .header(header::CONTENT_TYPE, "application/json");
 
-        let response = request.send().await?.text().await?;
+        let response = request.send().await?;
+        let attestable = response
+            .headers()
+            .get("graph-attestable")
+            .map_or(false, |v| v == "true");
+
         Ok(UnattestedQueryResult {
-            graphql_response: response,
-            attestable: true,
+            graphQLResponse: response.text().await?,
+            attestable,
         })
     }
 
@@ -54,7 +59,7 @@ impl GraphNodeInstance {
         // actually parse the JSON for the graphQL schema
         let response_text = response.text().await?;
         Ok(UnattestedQueryResult {
-            graphql_response: response_text,
+            graphQLResponse: response_text,
             attestable: false,
         })
     }

--- a/service/src/graph_node.rs
+++ b/service/src/graph_node.rs
@@ -38,7 +38,7 @@ impl GraphNodeInstance {
             .map_or(false, |v| v == "true");
 
         Ok(UnattestedQueryResult {
-            graphQLResponse: response.text().await?,
+            graphql_response: response.text().await?,
             attestable,
         })
     }
@@ -59,7 +59,7 @@ impl GraphNodeInstance {
         // actually parse the JSON for the graphQL schema
         let response_text = response.text().await?;
         Ok(UnattestedQueryResult {
-            graphQLResponse: response_text,
+            graphql_response: response_text,
             attestable: false,
         })
     }

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -89,16 +89,16 @@ pub struct Signature {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(non_snake_case)] // Need exact field names for JSON response
 pub struct QueryResult {
-    pub graphQLResponse: String,
+    #[serde(rename = "graphQLResponse")]
+    pub graphql_response: String,
     pub attestation: Option<Signature>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(non_snake_case)] // Need exact field names for JSON response
 pub struct UnattestedQueryResult {
-    pub graphQLResponse: String,
+    #[serde(rename = "graphQLResponse")]
+    pub graphql_response: String,
     pub attestable: bool,
 }
 

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -114,7 +114,6 @@ pub struct Response<T> {
 #[derive(Debug)]
 pub struct FreeQuery {
     pub subgraph_deployment_id: SubgraphDeploymentID,
-    // TODO: Use Arc<String> instead of String?
     pub query: String,
 }
 

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -80,20 +80,25 @@ impl ToString for SubgraphDeploymentID {
         self.hex()
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Signature {
     v: i64,
     r: String,
     s: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(non_snake_case)] // Need exact field names for JSON response
 pub struct QueryResult {
-    graphql_response: String,
-    attestation: Option<Signature>,
+    pub graphQLResponse: String,
+    pub attestation: Option<Signature>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(non_snake_case)] // Need exact field names for JSON response
 pub struct UnattestedQueryResult {
-    pub graphql_response: String,
+    pub graphQLResponse: String,
     pub attestable: bool,
 }
 
@@ -109,6 +114,7 @@ pub struct Response<T> {
 #[derive(Debug)]
 pub struct FreeQuery {
     pub subgraph_deployment_id: SubgraphDeploymentID,
+    // TODO: Use Arc<String> instead of String?
     pub query: String,
 }
 

--- a/service/src/server/routes/network.rs
+++ b/service/src/server/routes/network.rs
@@ -4,7 +4,6 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use hyper::http::HeaderName;
 
 use crate::server::ServerOptions;
 
@@ -43,18 +42,7 @@ pub async fn network_queries(
         .expect("Failed to execute free network subgraph query");
 
     match request.status {
-        200 => {
-            let response_body = request.result.graphql_response;
-            (
-                StatusCode::OK,
-                axum::response::AppendHeaders([(
-                    HeaderName::from_static("graph-attestable"),
-                    "false",
-                )]),
-                Json(response_body),
-            )
-                .into_response()
-        }
+        200 => (StatusCode::OK, Json(request.result)).into_response(),
         _ => bad_request_response("Bad response from Graph node"),
     }
 }

--- a/service/src/server/routes/subgraphs.rs
+++ b/service/src/server/routes/subgraphs.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Extension,
-    http::{self, HeaderName, Request, StatusCode},
+    http::{self, Request, StatusCode},
     response::IntoResponse,
     Json,
 };
@@ -69,19 +69,7 @@ pub async fn subgraph_queries(
             .expect("Failed to execute free query");
 
         match res.status {
-            200 => {
-                let response_body = res.result.graphql_response;
-                let attestable = res.result.attestable;
-                (
-                    StatusCode::OK,
-                    axum::response::AppendHeaders([(
-                        HeaderName::from_static("graph-attestable"),
-                        if attestable { "true" } else { "false" },
-                    )]),
-                    Json(response_body),
-                )
-                    .into_response()
-            }
+            200 => (StatusCode::OK, Json(res.result)).into_response(),
             _ => bad_request_response("Bad response from Graph node"),
         }
     } else {


### PR DESCRIPTION
Mostly to make it behave like the original `indexer-service`.