### PR TITLE
fix: take QmHash to construct subgraph deployment id

### DIFF
--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -1,4 +1,5 @@
 use log::error;
+use regex::Regex;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +27,16 @@ impl ToString for SubgraphName {
     }
 }
 
+/// Security: Input validation
+pub fn bytes32_check() -> Regex {
+    Regex::new(r"^0x[0-9a-f]{64}$").unwrap()
+}
+
+/// Security: Input Validation
+pub fn multihash_check() -> Regex {
+    Regex::new(r"^Qm[1-9a-km-zA-HJ-NP-Z]{44}$").unwrap()
+}
+
 /// Subgraph identifier type: SubgraphDeploymentID with field 'value'
 #[derive(Debug)]
 pub struct SubgraphDeploymentID {
@@ -35,6 +46,19 @@ pub struct SubgraphDeploymentID {
 
 /// Implement SubgraphDeploymentID functions
 impl SubgraphDeploymentID {
+    /// Construct SubgraphDeploymentID from a string
+    /// Validate IPFS hash or hex format before decoding
+    pub fn new(id: &str) -> anyhow::Result<SubgraphDeploymentID> {
+        // Security: Input validation
+        if multihash_check().is_match(id) {
+            Self::from_ipfs_hash(id)
+        } else if bytes32_check().is_match(id) {
+            Self::from_hex(id)
+        } else {
+            return Err(anyhow::anyhow!("Invalid subgraph deployment ID: {}", id));
+        }
+    }
+
     /// Construct SubgraphDeploymentID from a 32 bytes hex string.
     /// The '0x' prefix is optional.
     ///

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -1,5 +1,4 @@
 use log::error;
-use regex::Regex;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 
@@ -27,16 +26,6 @@ impl ToString for SubgraphName {
     }
 }
 
-/// Security: Input validation
-pub fn bytes32_check() -> Regex {
-    Regex::new(r"^0x[0-9a-f]{64}$").unwrap()
-}
-
-/// Security: Input Validation
-pub fn multihash_check() -> Regex {
-    Regex::new(r"^Qm[1-9a-km-zA-HJ-NP-Z]{44}$").unwrap()
-}
-
 /// Subgraph identifier type: SubgraphDeploymentID with field 'value'
 #[derive(Debug)]
 pub struct SubgraphDeploymentID {
@@ -49,14 +38,9 @@ impl SubgraphDeploymentID {
     /// Construct SubgraphDeploymentID from a string
     /// Validate IPFS hash or hex format before decoding
     pub fn new(id: &str) -> anyhow::Result<SubgraphDeploymentID> {
-        // Security: Input validation
-        if multihash_check().is_match(id) {
-            Self::from_ipfs_hash(id)
-        } else if bytes32_check().is_match(id) {
-            Self::from_hex(id)
-        } else {
-            return Err(anyhow::anyhow!("Invalid subgraph deployment ID: {}", id));
-        }
+        SubgraphDeploymentID::from_hex(id)
+            .or_else(|_| SubgraphDeploymentID::from_ipfs_hash(id))
+            .map_err(|_| anyhow::anyhow!("Invalid subgraph deployment ID: {}", id))
     }
 
     /// Construct SubgraphDeploymentID from a 32 bytes hex string.
@@ -207,6 +191,7 @@ impl QueryProcessor {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -236,15 +221,33 @@ mod tests {
     }
 
     #[test]
-    fn subgraph_deployment_id_input_validation() {
+    fn subgraph_deployment_id_input_validation_success() {
+        let deployment_id = "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884abf";
+        let ipfs_hash = "QmcPHxcC2ZN7m79XfYZ77YmF4t9UCErv87a9NFKrSLWKtJ";
+
+        assert_eq!(
+            SubgraphDeploymentID::new(ipfs_hash).unwrap().to_string(),
+            deployment_id
+        );
+
+        assert_eq!(
+            SubgraphDeploymentID::new(deployment_id)
+                .unwrap()
+                .ipfs_hash(),
+            ipfs_hash
+        );
+    }
+
+    #[test]
+    fn subgraph_deployment_id_input_validation_fail() {
         let invalid_deployment_id =
             "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884a";
         let invalid_ipfs_hash = "Qm1234";
 
-        let res = SubgraphDeploymentID::from_hex(invalid_deployment_id);
+        let res = SubgraphDeploymentID::new(invalid_deployment_id);
         assert!(res.is_err());
 
-        let res = SubgraphDeploymentID::from_ipfs_hash(invalid_ipfs_hash);
+        let res = SubgraphDeploymentID::new(invalid_ipfs_hash);
         assert!(res.is_err());
     }
 }

--- a/service/src/server/routes/subgraphs.rs
+++ b/service/src/server/routes/subgraphs.rs
@@ -55,7 +55,10 @@ pub async fn subgraph_queries(
     };
 
     // Initialize id into a subgraph deployment ID
-    let subgraph_deployment_id = SubgraphDeploymentID::from_hex(id.as_str()).unwrap();
+    let subgraph_deployment_id = match SubgraphDeploymentID::new(id.as_str()) {
+        Ok(id) => id,
+        Err(e) => return bad_request_response(&e.to_string()),
+    };
 
     if free {
         let free_query = FreeQuery {


### PR DESCRIPTION
It seems that the subgraph queries take `:id` as ipfs hash of a subgraph as well as the hex representation. 

og indexer-service [constructs](https://github.com/graphprotocol/indexer/blob/main/packages/indexer-service/src/server/index.ts#L249C28-L249C28) subgraph deployment id which calls out to common-ts [here](https://github.com/graphprotocol/common-ts/blob/f300c979bc1c2f643826439f06c0cec5c95a2a4b/packages/common-ts/src/subgraphs/index.ts#L27C4-L27C4)

