### PR TITLE
refactor: move graph-node instance to main

### DIFF
--- a/service/src/graph_node.rs
+++ b/service/src/graph_node.rs
@@ -1,16 +1,21 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use reqwest::{header, Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::query_processor::UnattestedQueryResult;
 
+/// Graph node query wrapper.
+///
+/// This is Arc internally, so it can be cloned and shared between threads.
 #[derive(Debug, Clone)]
 pub struct GraphNodeInstance {
-    client: Client,
-    base_url: String,
+    client: Client, // it is Arc
+    base_url: Arc<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,13 +27,14 @@ struct GraphQLQuery {
 
 impl GraphNodeInstance {
     pub fn new(base_url: &str) -> GraphNodeInstance {
+        let base_url = Url::parse(base_url).expect("Could not parse graph node endpoint");
         let client = reqwest::Client::builder()
             .user_agent("indexer-service")
             .build()
             .expect("Could not build a client to graph node query endpoint");
         GraphNodeInstance {
             client,
-            base_url: base_url.to_string(),
+            base_url: Arc::new(base_url.to_string()),
         }
     }
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -58,14 +58,12 @@ async fn main() -> Result<(), std::io::Error> {
     // Initialize graph-node client
     let graph_node = graph_node::GraphNodeInstance::new(
         &config.indexer_infrastructure.graph_node_query_endpoint,
+        &config.network_subgraph.network_subgraph_endpoint,
     );
 
     // Proper initiation of server, query processor
     // server health check, graph-node instance connection check
-    let query_processor = QueryProcessor::new(
-        graph_node.clone(),
-        &config.network_subgraph.network_subgraph_endpoint,
-    );
+    let query_processor = QueryProcessor::new(graph_node.clone());
 
     // Start indexer service basic metrics
     tokio::spawn(handle_serve_metrics(

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -55,10 +55,15 @@ async fn main() -> Result<(), std::io::Error> {
     let config = Cli::args();
     let release = package_version().expect("Failed to resolve for release version");
 
+    // Initialize graph-node client
+    let graph_node = graph_node::GraphNodeInstance::new(
+        &config.indexer_infrastructure.graph_node_query_endpoint,
+    );
+
     // Proper initiation of server, query processor
     // server health check, graph-node instance connection check
     let query_processor = QueryProcessor::new(
-        &config.indexer_infrastructure.graph_node_query_endpoint,
+        graph_node.clone(),
         &config.network_subgraph.network_subgraph_endpoint,
     );
 

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -7,7 +7,6 @@ use ethers_core::types::Address;
 use ethers_core::types::{Signature, U256};
 use log::error;
 use native::attestation::AttestationSigner;
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use tap_core::tap_manager::SignedReceipt;
 
@@ -149,16 +148,13 @@ pub enum QueryError {
 #[derive(Debug, Clone)]
 pub struct QueryProcessor {
     graph_node: GraphNodeInstance,
-    network_subgraph: Url,
     signers: HashMap<Address, AttestationSigner>,
 }
 
 impl QueryProcessor {
-    pub fn new(graph_node: GraphNodeInstance, network_subgraph_endpoint: &str) -> QueryProcessor {
+    pub fn new(graph_node: GraphNodeInstance) -> QueryProcessor {
         QueryProcessor {
             graph_node,
-            network_subgraph: Url::parse(network_subgraph_endpoint)
-                .expect("Could not parse graph node endpoint"),
             // TODO: populate signers
             signers: HashMap::new(),
         }
@@ -183,10 +179,7 @@ impl QueryProcessor {
         &self,
         query: String,
     ) -> Result<Response<UnattestedQueryResult>, QueryError> {
-        let response = self
-            .graph_node
-            .network_query_raw(self.network_subgraph.clone(), query)
-            .await?;
+        let response = self.graph_node.network_query_raw(query).await?;
 
         Ok(Response {
             result: response,

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -7,7 +7,7 @@ use ethers_core::types::Address;
 use ethers_core::types::{Signature, U256};
 use log::error;
 use native::attestation::AttestationSigner;
-use reqwest::{Client, Url};
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use tap_core::tap_manager::SignedReceipt;
 
@@ -148,20 +148,14 @@ pub enum QueryError {
 
 #[derive(Debug, Clone)]
 pub struct QueryProcessor {
-    client: Client,
-    base: Url,
     graph_node: GraphNodeInstance,
     network_subgraph: Url,
     signers: HashMap<Address, AttestationSigner>,
 }
 
 impl QueryProcessor {
-    pub fn new(graph_node_endpoint: &str, network_subgraph_endpoint: &str) -> QueryProcessor {
-        let graph_node = GraphNodeInstance::new(graph_node_endpoint);
-
+    pub fn new(graph_node: GraphNodeInstance, network_subgraph_endpoint: &str) -> QueryProcessor {
         QueryProcessor {
-            client: Client::new(),
-            base: Url::parse(graph_node_endpoint).expect("Could not parse graph node endpoint"),
             graph_node,
             network_subgraph: Url::parse(network_subgraph_endpoint)
                 .expect("Could not parse graph node endpoint"),


### PR DESCRIPTION
Small change that will make it easier to share the graph-node instance wrapper with other flows, such as the allocation monitor.