### PR TITLE
feat: slow and network ratelimiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4514,6 +4514,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 axum = "0.5"
 hyper = "0.14.27"
-tower = { version = "0.4", features = ["util", "timeout"] }
+tower = { version = "0.4", features = ["util", "timeout", "limit"] }
 tower-http = { version = "0.4.0", features = ["add-extension", "trace", "cors"] }
 env_logger = "0.9.0"
 toml = "0.7.4"

--- a/service/src/server/routes/mod.rs
+++ b/service/src/server/routes/mod.rs
@@ -8,6 +8,7 @@ use axum::{
     Json,
 };
 use hyper::http::HeaderName;
+use tower::limit::RateLimitLayer;
 
 pub mod basic;
 pub mod deployment;
@@ -51,4 +52,14 @@ pub fn internal_server_error_response(error_body: &str) -> Response {
         Json(error_body.to_string()),
     )
         .into_response()
+}
+
+/// Limit status requests to 9000/30min (5/s)
+pub fn slow_ratelimiter() -> RateLimitLayer {
+    RateLimitLayer::new(9000, std::time::Duration::from_millis(30 * 60 * 1000))
+}
+
+/// Limit network requests to 90000/30min (50/s)
+pub fn network_ratelimiter() -> RateLimitLayer {
+    RateLimitLayer::new(90000, std::time::Duration::from_millis(30 * 60 * 1000))
 }


### PR DESCRIPTION
Add slower ratelimiter (9000/30min == 5/s) to subgraph health checks and operator information
Add network ratelimiter (90000/30min == 50/s) to public status API and network subgraph queries
part of https://github.com/graphops/indexer-service-rs/issues/5