### PR TITLE
feat: attestation signers added to allocation monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,6 +2122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4102,7 @@ dependencies = [
  "ethers-core",
  "graphql-parser",
  "hex",
+ "hex-literal",
  "hyper",
  "lazy_static",
  "libsecp256k1",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -60,6 +60,7 @@ tap_core = "0.3.0"
 ethereum-types = "0.14.1"
 
 [dev-dependencies]
+hex-literal = "0.4.1"
 test-log = "0.2.12"
 wiremock = "0.5.19"
 

--- a/service/src/allocation_monitor.rs
+++ b/service/src/allocation_monitor.rs
@@ -1,25 +1,36 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
+use ethereum_types::U256;
 use ethers::types::Address;
 
 use log::{info, warn};
+use native::attestation::AttestationSigner;
 use tokio::sync::RwLock;
 
-use crate::common::{allocation::Allocation, network_subgraph::NetworkSubgraph};
+use crate::{
+    common::allocation::{allocation_signer, Allocation},
+    common::network_subgraph::NetworkSubgraph,
+    util::create_attestation_signer,
+};
 
+#[derive(Debug)]
 struct AllocationMonitorInner {
     network_subgraph: NetworkSubgraph,
     indexer_address: Address,
     interval_ms: u64,
     graph_network_id: u64,
     eligible_allocations: Arc<RwLock<Vec<Allocation>>>,
+    attestation_signers: Arc<RwLock<HashMap<Address, AttestationSigner>>>,
+    indexer_mnemonic: String,
+    chain_id: U256,
+    dispute_manager: Address,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AllocationMonitor {
     monitor_handle: Arc<tokio::task::JoinHandle<()>>,
     inner: Arc<AllocationMonitorInner>,
@@ -31,6 +42,9 @@ impl AllocationMonitor {
         indexer_address: Address,
         graph_network_id: u64,
         interval_ms: u64,
+        indexer_mnemonic: String,
+        chain_id: U256,
+        dispute_manager: Address,
     ) -> Result<Self> {
         let inner = Arc::new(AllocationMonitorInner {
             network_subgraph,
@@ -38,6 +52,10 @@ impl AllocationMonitor {
             interval_ms,
             graph_network_id,
             eligible_allocations: Arc::new(RwLock::new(Vec::new())),
+            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
+            indexer_mnemonic,
+            chain_id,
+            dispute_manager,
         });
 
         let inner_clone = inner.clone();
@@ -184,7 +202,7 @@ impl AllocationMonitor {
         Ok(eligible_allocations)
     }
 
-    async fn update(inner: &Arc<AllocationMonitorInner>) -> Result<(), anyhow::Error> {
+    async fn update_allocations(inner: &Arc<AllocationMonitorInner>) -> Result<(), anyhow::Error> {
         let current_epoch =
             Self::current_epoch(&inner.network_subgraph, inner.graph_network_id).await?;
         *(inner.eligible_allocations.write().await) = Self::current_eligible_allocations(
@@ -196,11 +214,44 @@ impl AllocationMonitor {
         Ok(())
     }
 
+    async fn update_attestation_signers(inner: &Arc<AllocationMonitorInner>) {
+        let mut attestation_signers_write = inner.attestation_signers.write().await;
+        for allocation in inner.eligible_allocations.read().await.iter() {
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                attestation_signers_write.entry(allocation.id)
+            {
+                match allocation_signer(&inner.indexer_mnemonic, allocation).and_then(|signer| {
+                    create_attestation_signer(
+                        inner.chain_id,
+                        inner.dispute_manager,
+                        signer,
+                        allocation.subgraph_deployment.id.bytes32(),
+                    )
+                }) {
+                    Ok(signer) => {
+                        e.insert(signer);
+                        info!(
+                            "Found attestation signer for {{allocation: {}, deployment: {}}}",
+                            allocation.id,
+                            allocation.subgraph_deployment.id.ipfs_hash()
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                        "Failed to find the attestation signer for {{allocation: {}, deployment: {}, createdAtEpoch: {}, err: {}}}",
+                        allocation.id, allocation.subgraph_deployment.id.ipfs_hash(), allocation.created_at_epoch, e
+                    )
+                    }
+                }
+            }
+        }
+    }
+
     async fn monitor_loop(inner: &Arc<AllocationMonitorInner>) -> Result<()> {
         loop {
-            let res = Self::update(inner).await;
+            let update_allocations_result = Self::update_allocations(inner).await;
 
-            if res.is_err() {
+            if update_allocations_result.is_err() {
                 warn!(
                     "Failed to query indexer allocations, keeping existing: {:?}. Error: {}",
                     inner
@@ -210,7 +261,8 @@ impl AllocationMonitor {
                         .iter()
                         .map(|e| { e.id })
                         .collect::<Vec<Address>>(),
-                    res.err()
+                    update_allocations_result
+                        .err()
                         .unwrap_or_else(|| anyhow::anyhow!("Unknown error"))
                 );
             }
@@ -234,6 +286,8 @@ impl AllocationMonitor {
                     .join(", ")
             );
 
+            Self::update_attestation_signers(inner).await;
+
             tokio::time::sleep(tokio::time::Duration::from_millis(inner.interval_ms)).await;
         }
     }
@@ -243,42 +297,140 @@ impl AllocationMonitor {
     ) -> tokio::sync::RwLockReadGuard<'_, Vec<Allocation>> {
         self.inner.eligible_allocations.read().await
     }
+
+    pub async fn get_attestation_signers(
+        &self,
+    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<Address, AttestationSigner>> {
+        self.inner.attestation_signers.read().await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use ethereum_types::U256;
     use test_log::test;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::*;
     use crate::common::types::SubgraphDeploymentID;
     use crate::common::{
         allocation::{AllocationStatus, SubgraphDeployment},
         network_subgraph::NetworkSubgraph,
     };
 
+    use super::*;
+
+    const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const INDEXER_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
+    const NETWORK_SUBGRAPH_ID: &str = "QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP";
+    const DISPUTE_MANAGER_ADDRESS: &str = "0xdeadbeefcafebabedeadbeefcafebabedeadbeef";
+
+    /// The allocation IDs below are generated using the mnemonic
+    /// "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    /// and the following epoch and index:
+    ///
+    /// - (createdAtEpoch, 0)
+    /// - (createdAtEpoch-1, 0)
+    /// - (createdAtEpoch, 2)
+    /// - (createdAtEpoch-1, 1)
+    ///
+    /// Using https://github.com/graphprotocol/indexer/blob/f8786c979a8ed0fae93202e499f5ce25773af473/packages/indexer-common/src/allocations/keys.ts#L41-L71
+    const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
+        {
+            "data": {
+                "indexer": {
+                    "activeAllocations": [
+                        {
+                            "id": "0xfa44c72b753a66591f241c7dc04e8178c30e13af",
+                            "indexer": {
+                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                            },
+                            "allocatedTokens": "5081382841000000014901161",
+                            "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
+                            "createdAtEpoch": 953,
+                            "closedAtEpoch": null,
+                            "subgraphDeployment": {
+                                "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                                "deniedAt": 0,
+                                "stakedTokens": "96183284152000000014901161",
+                                "signalledTokens": "182832939554154667498047",
+                                "queryFeesAmount": "19861336072168874330350"
+                            }
+                        },
+                        {
+                            "id": "0xdd975e30aafebb143e54d215db8a3e8fd916a701",
+                            "indexer": {
+                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                            },
+                            "allocatedTokens": "601726452999999979510903",
+                            "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
+                            "createdAtEpoch": 953,
+                            "closedAtEpoch": null,
+                            "subgraphDeployment": {
+                                "id": "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
+                                "deniedAt": 0,
+                                "stakedTokens": "53885041676589999979510903",
+                                "signalledTokens": "104257136417832003117925",
+                                "queryFeesAmount": "2229358609434396563687"
+                            }
+                        }
+                    ],
+                    "recentlyClosedAllocations": [
+                        {
+                            "id": "0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658",
+                            "indexer": {
+                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                            },
+                            "allocatedTokens": "5247998688000000081956387",
+                            "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
+                            "createdAtEpoch": 940,
+                            "closedAtEpoch": 953,
+                            "subgraphDeployment": {
+                                "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                                "deniedAt": 0,
+                                "stakedTokens": "96183284152000000014901161",
+                                "signalledTokens": "182832939554154667498047",
+                                "queryFeesAmount": "19861336072168874330350"
+                            }
+                        },
+                        {
+                            "id": "0x69f961358846fdb64b04e1fd7b2701237c13cd9a",
+                            "indexer": {
+                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                            },
+                            "allocatedTokens": "2502334654999999795109034",
+                            "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
+                            "createdAtEpoch": 940,
+                            "closedAtEpoch": 953,
+                            "subgraphDeployment": {
+                                "id": "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
+                                "deniedAt": 0,
+                                "stakedTokens": "85450761241000000055879354",
+                                "signalledTokens": "154944508746646550301048",
+                                "queryFeesAmount": "4293718622418791971020"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    "#;
+
     #[test(tokio::test)]
     async fn test_current_epoch() {
-        let network_subgraph_id = "QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP";
-        let _indexer_address =
-            Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
-
         let mock_server = MockServer::start().await;
 
         let network_subgraph_endpoint =
-            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), network_subgraph_id);
+            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
         let network_subgraph = NetworkSubgraph::new(
             Some(&mock_server.uri()),
-            Some(network_subgraph_id),
+            Some(NETWORK_SUBGRAPH_ID),
             network_subgraph_endpoint.as_ref(),
         );
 
         let mock = Mock::given(method("POST"))
-            .and(path("/subgraphs/id/".to_string() + network_subgraph_id))
+            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
             .respond_with(ResponseTemplate::new(200).set_body_raw(
                 r#"
                     {
@@ -303,105 +455,24 @@ mod tests {
 
     #[test(tokio::test)]
     async fn test_current_eligible_allocations() {
-        let network_subgraph_id = "QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP";
-        let indexer_address =
-            Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let indexer_address = Address::from_str(INDEXER_ADDRESS).unwrap();
 
         let mock_server = MockServer::start().await;
 
         let network_subgraph_endpoint =
-            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), network_subgraph_id);
+            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
         let network_subgraph = NetworkSubgraph::new(
             Some(&mock_server.uri()),
-            Some(network_subgraph_id),
+            Some(NETWORK_SUBGRAPH_ID),
             network_subgraph_endpoint.as_ref(),
         );
 
         let mock = Mock::given(method("POST"))
-            .and(path("/subgraphs/id/".to_string() + network_subgraph_id))
-            .respond_with(ResponseTemplate::new(200).set_body_raw(
-                r#"
-                    {
-                        "data": {
-                            "indexer": {
-                                "activeAllocations": [
-                                    {
-                                        "id": "0x0b1565a827f4b92849b17de9e3ca1fa1cc51e9a7",
-                                        "indexer": {
-                                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                                        },
-                                        "allocatedTokens": "5081382841000000014901161",
-                                        "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
-                                        "createdAtEpoch": 953,
-                                        "closedAtEpoch": null,
-                                        "subgraphDeployment": {
-                                            "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                                            "deniedAt": 0,
-                                            "stakedTokens": "96183284152000000014901161",
-                                            "signalledTokens": "182832939554154667498047",
-                                            "queryFeesAmount": "19861336072168874330350"
-                                        }
-                                    },
-                                    {
-                                        "id": "0x10ff1b029f28bfb8ec4badd5672478f27d574b7e",
-                                        "indexer": {
-                                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                                        },
-                                        "allocatedTokens": "601726452999999979510903",
-                                        "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
-                                        "createdAtEpoch": 953,
-                                        "closedAtEpoch": null,
-                                        "subgraphDeployment": {
-                                            "id": "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
-                                            "deniedAt": 0,
-                                            "stakedTokens": "53885041676589999979510903",
-                                            "signalledTokens": "104257136417832003117925",
-                                            "queryFeesAmount": "2229358609434396563687"
-                                        }
-                                    }
-                                ],
-                                "recentlyClosedAllocations": [
-                                    {
-                                        "id": "0xc6aea0f1271bca4629d21e33be4dc3c070538f05",
-                                        "indexer": {
-                                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                                        },
-                                        "allocatedTokens": "5247998688000000081956387",
-                                        "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
-                                        "createdAtEpoch": 940,
-                                        "closedAtEpoch": 953,
-                                        "subgraphDeployment": {
-                                            "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                                            "deniedAt": 0,
-                                            "stakedTokens": "96183284152000000014901161",
-                                            "signalledTokens": "182832939554154667498047",
-                                            "queryFeesAmount": "19861336072168874330350"
-                                        }
-                                    },
-                                    {
-                                        "id": "0xe255ecd4b78b1aeb7e5acf7d6dc43b4823c4461c",
-                                        "indexer": {
-                                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                                        },
-                                        "allocatedTokens": "2502334654999999795109034",
-                                        "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
-                                        "createdAtEpoch": 940,
-                                        "closedAtEpoch": 953,
-                                        "subgraphDeployment": {
-                                            "id": "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
-                                            "deniedAt": 0,
-                                            "stakedTokens": "85450761241000000055879354",
-                                            "signalledTokens": "154944508746646550301048",
-                                            "queryFeesAmount": "4293718622418791971020"
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                "#,
-                "application/json",
-            ));
+            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(ALLOCATIONS_QUERY_RESPONSE, "application/json"),
+            );
 
         mock_server.register(mock).await;
 
@@ -418,7 +489,7 @@ mod tests {
         assert_eq!(
             allocations[2],
             Allocation {
-                id: Address::from_str("0xc6aea0f1271bca4629d21e33be4dc3c070538f05").unwrap(),
+                id: Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap(),
                 indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
                 allocated_tokens: U256::from_str("5247998688000000081956387").unwrap(),
                 created_at_block_hash:
@@ -445,6 +516,59 @@ mod tests {
         );
     }
 
+    #[test(tokio::test)]
+    async fn test_update_attestation_signers() {
+        let indexer_address = Address::from_str(INDEXER_ADDRESS).unwrap();
+
+        let mock_server = MockServer::start().await;
+
+        let network_subgraph_endpoint =
+            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
+        let network_subgraph = NetworkSubgraph::new(
+            Some(&mock_server.uri()),
+            Some(NETWORK_SUBGRAPH_ID),
+            network_subgraph_endpoint.as_ref(),
+        );
+
+        let mock = Mock::given(method("POST"))
+            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(ALLOCATIONS_QUERY_RESPONSE, "application/json"),
+            );
+
+        mock_server.register(mock).await;
+
+        let inner = Arc::new(AllocationMonitorInner {
+            network_subgraph: network_subgraph.clone(),
+            indexer_address,
+            interval_ms: 1000,
+            graph_network_id: 1,
+            eligible_allocations: Arc::new(RwLock::new(Vec::new())),
+            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
+            indexer_mnemonic: INDEXER_OPERATOR_MNEMONIC.to_string(),
+            chain_id: U256::from(1),
+            dispute_manager: Address::from_str(DISPUTE_MANAGER_ADDRESS).unwrap(),
+        });
+
+        *(inner.eligible_allocations.write().await) =
+            AllocationMonitor::current_eligible_allocations(
+                &network_subgraph,
+                &indexer_address,
+                940,
+            )
+            .await
+            .unwrap();
+
+        AllocationMonitor::update_attestation_signers(&inner).await;
+
+        // Check that the attestation signers were found for the allocations
+        assert_eq!(
+            inner.attestation_signers.read().await.len(),
+            inner.eligible_allocations.read().await.len()
+        );
+    }
+
     /// Run with RUST_LOG=info to see the logs from the allocation monitor
     #[test(tokio::test)]
     #[ignore]
@@ -454,6 +578,8 @@ mod tests {
         let network_subgraph_id =
             std::env::var("NETWORK_SUBGRAPH_ID").expect("NETWORK_SUBGRAPH_ID not set");
         let indexer_address = std::env::var("INDEXER_ADDRESS").expect("INDEXER_ADDRESS not set");
+        // If you don't specify the correct mnemonic, the attestation signers won't be found
+        let indexer_mnemonic = std::env::var("INDEXER_MNEMONIC").expect("INDEXER_MNEMONIC not set");
 
         let network_subgraph_endpoint =
             NetworkSubgraph::local_deployment_endpoint(&graph_node_url, &network_subgraph_id);
@@ -469,6 +595,9 @@ mod tests {
             Address::from_str(&indexer_address).unwrap(),
             1,
             1000,
+            indexer_mnemonic,
+            U256::from(1),
+            Address::from_str(DISPUTE_MANAGER_ADDRESS).unwrap(),
         )
         .await
         .unwrap();

--- a/service/src/common/allocation.rs
+++ b/service/src/common/allocation.rs
@@ -1,6 +1,12 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
+use ethers::signers::coins_bip39::English;
+use ethers::signers::MnemonicBuilder;
+use ethers::signers::Signer;
+use ethers::signers::Wallet;
+use ethers_core::k256::ecdsa::SigningKey;
 use ethers_core::types::Address;
 use ethers_core::types::U256;
 use serde::Deserialize;
@@ -86,5 +92,170 @@ impl<'d> Deserialize<'d> for Allocation {
             query_fee_rebates: None,
             query_fees_collected: None,
         })
+    }
+}
+
+pub fn derive_key_pair(
+    indexer_mnemonic: &str,
+    epoch: u64,
+    deployment: &SubgraphDeploymentID,
+    index: u64,
+) -> Result<Wallet<SigningKey>> {
+    let mut derivation_path = format!("m/{}/", epoch);
+    derivation_path.push_str(
+        &deployment
+            .ipfs_hash()
+            .as_bytes()
+            .iter()
+            .map(|char| char.to_string())
+            .collect::<Vec<String>>()
+            .join("/"),
+    );
+    derivation_path.push_str(format!("/{}", index).as_str());
+
+    Ok(MnemonicBuilder::<English>::default()
+        .derivation_path(&derivation_path)
+        .expect("Valid derivation path")
+        .phrase(indexer_mnemonic)
+        .build()?)
+}
+
+pub fn allocation_signer(indexer_mnemonic: &str, allocation: &Allocation) -> Result<SigningKey> {
+    // Guess the allocation index by enumerating all indexes in the
+    // range [0, 100] and checking for a match
+    for i in 0..100 {
+        // The allocation was either created at the epoch it intended to or one
+        // epoch later. So try both both.
+        for created_at_epoch in [allocation.created_at_epoch, allocation.created_at_epoch - 1] {
+            let allocation_wallet = derive_key_pair(
+                indexer_mnemonic,
+                created_at_epoch,
+                &allocation.subgraph_deployment.id,
+                i,
+            )?;
+            if allocation_wallet.address() == allocation.id {
+                return Ok(allocation_wallet.signer().clone());
+            }
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Could not find allocation signer for allocation {}",
+        allocation.id
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::common::types::SubgraphDeploymentID;
+
+    const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    #[test]
+    fn test_derive_key_pair() {
+        assert_eq!(
+            derive_key_pair(
+                INDEXER_OPERATOR_MNEMONIC,
+                953,
+                &SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
+                )
+                .unwrap(),
+                0
+            )
+            .unwrap()
+            .address(),
+            Address::from_str("0xfa44c72b753a66591f241c7dc04e8178c30e13af").unwrap()
+        );
+
+        assert_eq!(
+            derive_key_pair(
+                INDEXER_OPERATOR_MNEMONIC,
+                940,
+                &SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
+                )
+                .unwrap(),
+                2
+            )
+            .unwrap()
+            .address(),
+            Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_allocation_signer() {
+        // Note that we use `derive_key_pair` to derive the private key
+
+        let allocation = Allocation {
+            id: Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap(),
+            status: AllocationStatus::Null,
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                )
+                .unwrap(),
+                denied_at: None,
+                staked_tokens: U256::zero(),
+                signalled_tokens: U256::zero(),
+                query_fees_amount: U256::zero(),
+            },
+            indexer: Address::zero(),
+            allocated_tokens: U256::zero(),
+            created_at_epoch: 940,
+            created_at_block_hash: "".to_string(),
+            closed_at_epoch: None,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        };
+        assert_eq!(
+            allocation_signer(INDEXER_OPERATOR_MNEMONIC, &allocation).unwrap(),
+            *derive_key_pair(
+                INDEXER_OPERATOR_MNEMONIC,
+                940,
+                &allocation.subgraph_deployment.id,
+                2
+            )
+            .unwrap()
+            .signer()
+        );
+    }
+
+    #[test]
+    fn test_allocation_signer_error() {
+        // Note that because allocation will try 200 derivations paths, this is a slow test
+
+        let allocation = Allocation {
+            // Purposefully wrong address
+            id: Address::from_str("0xdeadbeefcafebabedeadbeefcafebabedeadbeef").unwrap(),
+            status: AllocationStatus::Null,
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                )
+                .unwrap(),
+                denied_at: None,
+                staked_tokens: U256::zero(),
+                signalled_tokens: U256::zero(),
+                query_fees_amount: U256::zero(),
+            },
+            indexer: Address::zero(),
+            allocated_tokens: U256::zero(),
+            created_at_epoch: 940,
+            created_at_block_hash: "".to_string(),
+            closed_at_epoch: None,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        };
+        assert!(allocation_signer(INDEXER_OPERATOR_MNEMONIC, &allocation).is_err());
     }
 }

--- a/service/src/common/types.rs
+++ b/service/src/common/types.rs
@@ -35,7 +35,7 @@ impl ToString for SubgraphName {
 }
 
 /// Subgraph identifier type: SubgraphDeploymentID with field 'value'
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SubgraphDeploymentID {
     // bytes32 subgraph deployment Id
     value: [u8; 32],

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -1,15 +1,13 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
-use ethers_core::types::Address;
 use ethers_core::types::{Signature, U256};
 use log::error;
 use native::attestation::AttestationSigner;
 use serde::{Deserialize, Serialize};
 use tap_core::tap_manager::SignedReceipt;
 
+use crate::allocation_monitor::AllocationMonitor;
 use crate::common::types::SubgraphDeploymentID;
 use crate::graph_node::GraphNodeInstance;
 
@@ -64,15 +62,17 @@ pub enum QueryError {
 #[derive(Debug, Clone)]
 pub struct QueryProcessor {
     graph_node: GraphNodeInstance,
-    signers: HashMap<Address, AttestationSigner>,
+    allocation_monitor: AllocationMonitor,
 }
 
 impl QueryProcessor {
-    pub fn new(graph_node: GraphNodeInstance) -> QueryProcessor {
+    pub fn new(
+        graph_node: GraphNodeInstance,
+        allocation_monitor: AllocationMonitor,
+    ) -> QueryProcessor {
         QueryProcessor {
             graph_node,
-            // TODO: populate signers
-            signers: HashMap::new(),
+            allocation_monitor,
         }
     }
 
@@ -109,7 +109,8 @@ impl QueryProcessor {
 
         // TODO: Handle the TAP receipt
 
-        let signer = self.signers.get(&allocation_id).ok_or_else(|| {
+        let signers = self.allocation_monitor.get_attestation_signers().await;
+        let signer = signers.get(&allocation_id).ok_or_else(|| {
             QueryError::Other(anyhow::anyhow!(
                 "No signer found for allocation id {}",
                 allocation_id
@@ -121,15 +122,9 @@ impl QueryProcessor {
             .subgraph_query_raw(&subgraph_deployment_id.ipfs_hash(), query.clone())
             .await?;
 
-        let attestation_signature = response.attestable.then(|| {
-            // TODO: Need to check correctness of this. In particular, the endianness.
-            let attestation = signer.create_attestation(&query, &response.graphql_response);
-            Signature {
-                r: U256::from_big_endian(&attestation.r),
-                s: U256::from_big_endian(&attestation.s),
-                v: attestation.v as u64,
-            }
-        });
+        let attestation_signature = response
+            .attestable
+            .then(|| Self::create_attestation(signer, query, &response));
 
         Ok(Response {
             result: QueryResult {
@@ -138,5 +133,153 @@ impl QueryProcessor {
             },
             status: 200,
         })
+    }
+
+    fn create_attestation(
+        signer: &AttestationSigner,
+        query: String,
+        response: &UnattestedQueryResult,
+    ) -> Signature {
+        let attestation = signer.create_attestation(&query, &response.graphql_response);
+        Signature {
+            r: U256::from_big_endian(&attestation.r),
+            s: U256::from_big_endian(&attestation.s),
+            v: attestation.v as u64,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use ethereum_types::Address;
+    use hex_literal::hex;
+
+    use crate::{
+        common::allocation::{allocation_signer, Allocation, AllocationStatus, SubgraphDeployment},
+        util::create_attestation_signer,
+    };
+
+    use super::*;
+
+    const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const INDEXER_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
+
+    #[test]
+    fn hex_to_ipfs_multihash() {
+        let deployment_id = "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884abf";
+        let expected_ipfs_hash = "QmcPHxcC2ZN7m79XfYZ77YmF4t9UCErv87a9NFKrSLWKtJ";
+
+        assert_eq!(
+            SubgraphDeploymentID::from_hex(deployment_id)
+                .unwrap()
+                .ipfs_hash(),
+            expected_ipfs_hash
+        );
+    }
+
+    #[test]
+    fn ipfs_multihash_to_hex() {
+        let deployment_id = "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884abf";
+        let ipfs_hash = "QmcPHxcC2ZN7m79XfYZ77YmF4t9UCErv87a9NFKrSLWKtJ";
+
+        assert_eq!(
+            SubgraphDeploymentID::from_ipfs_hash(ipfs_hash)
+                .unwrap()
+                .to_string(),
+            deployment_id
+        );
+    }
+
+    #[test]
+    fn subgraph_deployment_id_input_validation_success() {
+        let deployment_id = "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884abf";
+        let ipfs_hash = "QmcPHxcC2ZN7m79XfYZ77YmF4t9UCErv87a9NFKrSLWKtJ";
+
+        assert_eq!(
+            SubgraphDeploymentID::new(ipfs_hash).unwrap().to_string(),
+            deployment_id
+        );
+
+        assert_eq!(
+            SubgraphDeploymentID::new(deployment_id)
+                .unwrap()
+                .ipfs_hash(),
+            ipfs_hash
+        );
+    }
+
+    #[test]
+    fn subgraph_deployment_id_input_validation_fail() {
+        let invalid_deployment_id =
+            "0xd0b0e5b65df45a3fff1a653b4188881318e8459d3338f936aab16c4003884a";
+        let invalid_ipfs_hash = "Qm1234";
+
+        let res = SubgraphDeploymentID::new(invalid_deployment_id);
+        assert!(res.is_err());
+
+        let res = SubgraphDeploymentID::new(invalid_ipfs_hash);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn paid_query_attestation() {
+        let subgraph_deployment_id = SubgraphDeploymentID::new(
+            "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
+        )
+        .unwrap();
+
+        let subgraph_deployment = SubgraphDeployment {
+            id: subgraph_deployment_id.clone(),
+            denied_at: None,
+            staked_tokens: U256::from(0),
+            signalled_tokens: U256::from(0),
+            query_fees_amount: U256::from(0),
+        };
+
+        let allocation = &Allocation {
+            id: Address::from_str("0x4CAF2827961262ADEF3D0Ad15C341e40c21389a4").unwrap(),
+            status: AllocationStatus::Null,
+            subgraph_deployment,
+            indexer: Address::from_str(INDEXER_ADDRESS).unwrap(),
+            allocated_tokens: U256::from(100),
+            created_at_epoch: 940,
+            created_at_block_hash: String::from(""),
+            closed_at_epoch: None,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        };
+
+        let allocation_key = allocation_signer(INDEXER_OPERATOR_MNEMONIC, allocation).unwrap();
+
+        let attestation_signer = create_attestation_signer(
+            U256::from(1),
+            Address::from_str("0xdeadbeefcafebabedeadbeefcafebabedeadbeef").unwrap(),
+            allocation_key,
+            subgraph_deployment_id.bytes32(),
+        )
+        .unwrap();
+
+        let attestation = QueryProcessor::create_attestation(
+            &attestation_signer,
+            "test input".to_string(),
+            &UnattestedQueryResult {
+                graphql_response: "test output".to_string(),
+                attestable: true,
+            },
+        );
+
+        // Values generated using https://github.com/graphprotocol/indexer/blob/f8786c979a8ed0fae93202e499f5ce25773af473/packages/indexer-native/lib/index.d.ts#L44
+        let expected_signature = Signature {
+            v: 27,
+            r: hex!("a0c83c0785e2223ac1ea1eb9e4ffd4ca867275469a7b73dab24f39ddcdec5466").into(),
+            s: hex!("4d0457efea889f2ec7ffcc7ff9b408428d0691356f34b01f419f7674d0eb4ddf").into(),
+        };
+
+        assert_eq!(attestation, expected_signature);
     }
 }


### PR DESCRIPTION
There is some weirdness due to type conversions to interface with the `native` crate. I think it'd be nice to refactor `native` to have it rely on external dependencies, to make it easier to understand and maintain in the future.