### PR TITLE
refactor: splitting off  `AttestationSigners`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "c121a894495d7d3fc3d4e15e0a9843e422e4d1d9e3c514d8062a1c94b35b005d"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling",
+ "darling 0.14.4",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1027,8 +1027,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1046,14 +1056,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1375,7 +1410,7 @@ dependencies = [
  "sha2 0.10.6",
  "sha3",
  "thiserror",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1703,6 +1738,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "faux"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b55a7f424e532314115b5cdc6d9711b15ac453bfe0dcfa212baebc5efacd60"
+dependencies = [
+ "faux_macros",
+ "paste",
+]
+
+[[package]]
+name = "faux_macros"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15473d7f83b54a44826907af16ae5727eaacaf6e53b51474016d3efd9aa35d5"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -3122,6 +3180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4164,7 @@ dependencies = [
  "ethers",
  "ethers-contract",
  "ethers-core",
+ "faux",
  "graphql-parser",
  "hex",
  "hex-literal",
@@ -5005,6 +5070,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.9",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom 0.2.9",
 ]
 
 [[package]]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -60,6 +60,7 @@ tap_core = "0.3.0"
 ethereum-types = "0.14.1"
 
 [dev-dependencies]
+faux = "0.1.10"
 hex-literal = "0.4.1"
 test-log = "0.2.12"
 wiremock = "0.5.19"

--- a/service/src/allocation_monitor.rs
+++ b/service/src/allocation_monitor.rs
@@ -1,21 +1,18 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
-use ethereum_types::U256;
+
 use ethers::types::Address;
 
 use log::{info, warn};
-use native::attestation::AttestationSigner;
+
+use tokio::sync::watch::{Receiver, Sender};
 use tokio::sync::RwLock;
 
-use crate::{
-    common::allocation::{allocation_signer, Allocation},
-    common::network_subgraph::NetworkSubgraph,
-    util::create_attestation_signer,
-};
+use crate::{common::allocation::Allocation, common::network_subgraph::NetworkSubgraph};
 
 #[derive(Debug)]
 struct AllocationMonitorInner {
@@ -24,44 +21,42 @@ struct AllocationMonitorInner {
     interval_ms: u64,
     graph_network_id: u64,
     eligible_allocations: Arc<RwLock<Vec<Allocation>>>,
-    attestation_signers: Arc<RwLock<HashMap<Address, AttestationSigner>>>,
-    indexer_mnemonic: String,
-    chain_id: U256,
-    dispute_manager: Address,
+    watch_sender: Sender<()>,
+    watch_receiver: Receiver<()>,
 }
 
+#[cfg_attr(test, faux::create)]
 #[derive(Debug, Clone)]
 pub struct AllocationMonitor {
-    monitor_handle: Arc<tokio::task::JoinHandle<()>>,
+    _monitor_handle: Arc<tokio::task::JoinHandle<()>>,
     inner: Arc<AllocationMonitorInner>,
 }
 
+#[cfg_attr(test, faux::methods)]
 impl AllocationMonitor {
     pub async fn new(
         network_subgraph: NetworkSubgraph,
         indexer_address: Address,
         graph_network_id: u64,
         interval_ms: u64,
-        indexer_mnemonic: String,
-        chain_id: U256,
-        dispute_manager: Address,
     ) -> Result<Self> {
+        // These are used to ping subscribers when the allocations are updated
+        let (watch_sender, watch_receiver) = tokio::sync::watch::channel(());
+
         let inner = Arc::new(AllocationMonitorInner {
             network_subgraph,
             indexer_address,
             interval_ms,
             graph_network_id,
             eligible_allocations: Arc::new(RwLock::new(Vec::new())),
-            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
-            indexer_mnemonic,
-            chain_id,
-            dispute_manager,
+            watch_sender,
+            watch_receiver,
         });
 
         let inner_clone = inner.clone();
 
         let monitor = AllocationMonitor {
-            monitor_handle: Arc::new(tokio::spawn(async move {
+            _monitor_handle: Arc::new(tokio::spawn(async move {
                 AllocationMonitor::monitor_loop(&inner_clone).await.unwrap();
             })),
             inner,
@@ -214,57 +209,29 @@ impl AllocationMonitor {
         Ok(())
     }
 
-    async fn update_attestation_signers(inner: &Arc<AllocationMonitorInner>) {
-        let mut attestation_signers_write = inner.attestation_signers.write().await;
-        for allocation in inner.eligible_allocations.read().await.iter() {
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                attestation_signers_write.entry(allocation.id)
-            {
-                match allocation_signer(&inner.indexer_mnemonic, allocation).and_then(|signer| {
-                    create_attestation_signer(
-                        inner.chain_id,
-                        inner.dispute_manager,
-                        signer,
-                        allocation.subgraph_deployment.id.bytes32(),
-                    )
-                }) {
-                    Ok(signer) => {
-                        e.insert(signer);
-                        info!(
-                            "Found attestation signer for {{allocation: {}, deployment: {}}}",
-                            allocation.id,
-                            allocation.subgraph_deployment.id.ipfs_hash()
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                        "Failed to find the attestation signer for {{allocation: {}, deployment: {}, createdAtEpoch: {}, err: {}}}",
-                        allocation.id, allocation.subgraph_deployment.id.ipfs_hash(), allocation.created_at_epoch, e
-                    )
-                    }
-                }
-            }
-        }
-    }
-
     async fn monitor_loop(inner: &Arc<AllocationMonitorInner>) -> Result<()> {
         loop {
-            let update_allocations_result = Self::update_allocations(inner).await;
-
-            if update_allocations_result.is_err() {
-                warn!(
-                    "Failed to query indexer allocations, keeping existing: {:?}. Error: {}",
-                    inner
-                        .eligible_allocations
-                        .read()
-                        .await
-                        .iter()
-                        .map(|e| { e.id })
-                        .collect::<Vec<Address>>(),
-                    update_allocations_result
-                        .err()
-                        .unwrap_or_else(|| anyhow::anyhow!("Unknown error"))
-                );
+            match Self::update_allocations(inner).await {
+                Ok(_) => {
+                    if inner.watch_sender.send(()).is_err() {
+                        warn!(
+                            "Failed to notify subscribers that the allocations have been updated"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to query indexer allocations, keeping existing: {:?}. Error: {}",
+                        inner
+                            .eligible_allocations
+                            .read()
+                            .await
+                            .iter()
+                            .map(|e| { e.id })
+                            .collect::<Vec<Address>>(),
+                        e
+                    );
+                }
             }
 
             info!(
@@ -286,8 +253,6 @@ impl AllocationMonitor {
                     .join(", ")
             );
 
-            Self::update_attestation_signers(inner).await;
-
             tokio::time::sleep(tokio::time::Duration::from_millis(inner.interval_ms)).await;
         }
     }
@@ -298,10 +263,8 @@ impl AllocationMonitor {
         self.inner.eligible_allocations.read().await
     }
 
-    pub async fn get_attestation_signers(
-        &self,
-    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<Address, AttestationSigner>> {
-        self.inner.attestation_signers.read().await
+    pub fn subscribe(&self) -> Receiver<()> {
+        self.inner.watch_receiver.clone()
     }
 }
 
@@ -313,124 +276,29 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use crate::common::types::SubgraphDeploymentID;
-    use crate::common::{
-        allocation::{AllocationStatus, SubgraphDeployment},
-        network_subgraph::NetworkSubgraph,
-    };
+    use crate::common::network_subgraph::NetworkSubgraph;
+    use crate::test_vectors;
 
     use super::*;
-
-    const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-    const INDEXER_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
-    const NETWORK_SUBGRAPH_ID: &str = "QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP";
-    const DISPUTE_MANAGER_ADDRESS: &str = "0xdeadbeefcafebabedeadbeefcafebabedeadbeef";
-
-    /// The allocation IDs below are generated using the mnemonic
-    /// "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-    /// and the following epoch and index:
-    ///
-    /// - (createdAtEpoch, 0)
-    /// - (createdAtEpoch-1, 0)
-    /// - (createdAtEpoch, 2)
-    /// - (createdAtEpoch-1, 1)
-    ///
-    /// Using https://github.com/graphprotocol/indexer/blob/f8786c979a8ed0fae93202e499f5ce25773af473/packages/indexer-common/src/allocations/keys.ts#L41-L71
-    const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
-        {
-            "data": {
-                "indexer": {
-                    "activeAllocations": [
-                        {
-                            "id": "0xfa44c72b753a66591f241c7dc04e8178c30e13af",
-                            "indexer": {
-                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                            },
-                            "allocatedTokens": "5081382841000000014901161",
-                            "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
-                            "createdAtEpoch": 953,
-                            "closedAtEpoch": null,
-                            "subgraphDeployment": {
-                                "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                                "deniedAt": 0,
-                                "stakedTokens": "96183284152000000014901161",
-                                "signalledTokens": "182832939554154667498047",
-                                "queryFeesAmount": "19861336072168874330350"
-                            }
-                        },
-                        {
-                            "id": "0xdd975e30aafebb143e54d215db8a3e8fd916a701",
-                            "indexer": {
-                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                            },
-                            "allocatedTokens": "601726452999999979510903",
-                            "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
-                            "createdAtEpoch": 953,
-                            "closedAtEpoch": null,
-                            "subgraphDeployment": {
-                                "id": "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
-                                "deniedAt": 0,
-                                "stakedTokens": "53885041676589999979510903",
-                                "signalledTokens": "104257136417832003117925",
-                                "queryFeesAmount": "2229358609434396563687"
-                            }
-                        }
-                    ],
-                    "recentlyClosedAllocations": [
-                        {
-                            "id": "0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658",
-                            "indexer": {
-                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                            },
-                            "allocatedTokens": "5247998688000000081956387",
-                            "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
-                            "createdAtEpoch": 940,
-                            "closedAtEpoch": 953,
-                            "subgraphDeployment": {
-                                "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                                "deniedAt": 0,
-                                "stakedTokens": "96183284152000000014901161",
-                                "signalledTokens": "182832939554154667498047",
-                                "queryFeesAmount": "19861336072168874330350"
-                            }
-                        },
-                        {
-                            "id": "0x69f961358846fdb64b04e1fd7b2701237c13cd9a",
-                            "indexer": {
-                                "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
-                            },
-                            "allocatedTokens": "2502334654999999795109034",
-                            "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
-                            "createdAtEpoch": 940,
-                            "closedAtEpoch": 953,
-                            "subgraphDeployment": {
-                                "id": "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
-                                "deniedAt": 0,
-                                "stakedTokens": "85450761241000000055879354",
-                                "signalledTokens": "154944508746646550301048",
-                                "queryFeesAmount": "4293718622418791971020"
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    "#;
 
     #[test(tokio::test)]
     async fn test_current_epoch() {
         let mock_server = MockServer::start().await;
 
-        let network_subgraph_endpoint =
-            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
+        let network_subgraph_endpoint = NetworkSubgraph::local_deployment_endpoint(
+            &mock_server.uri(),
+            test_vectors::NETWORK_SUBGRAPH_ID,
+        );
         let network_subgraph = NetworkSubgraph::new(
             Some(&mock_server.uri()),
-            Some(NETWORK_SUBGRAPH_ID),
+            Some(test_vectors::NETWORK_SUBGRAPH_ID),
             network_subgraph_endpoint.as_ref(),
         );
 
         let mock = Mock::given(method("POST"))
-            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
+            .and(path(
+                "/subgraphs/id/".to_string() + test_vectors::NETWORK_SUBGRAPH_ID,
+            ))
             .respond_with(ResponseTemplate::new(200).set_body_raw(
                 r#"
                     {
@@ -455,23 +323,27 @@ mod tests {
 
     #[test(tokio::test)]
     async fn test_current_eligible_allocations() {
-        let indexer_address = Address::from_str(INDEXER_ADDRESS).unwrap();
+        let indexer_address = Address::from_str(test_vectors::INDEXER_ADDRESS).unwrap();
 
         let mock_server = MockServer::start().await;
 
-        let network_subgraph_endpoint =
-            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
+        let network_subgraph_endpoint = NetworkSubgraph::local_deployment_endpoint(
+            &mock_server.uri(),
+            test_vectors::NETWORK_SUBGRAPH_ID,
+        );
         let network_subgraph = NetworkSubgraph::new(
             Some(&mock_server.uri()),
-            Some(NETWORK_SUBGRAPH_ID),
+            Some(test_vectors::NETWORK_SUBGRAPH_ID),
             network_subgraph_endpoint.as_ref(),
         );
 
         let mock = Mock::given(method("POST"))
-            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
+            .and(path(
+                "/subgraphs/id/".to_string() + test_vectors::NETWORK_SUBGRAPH_ID,
+            ))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_raw(ALLOCATIONS_QUERY_RESPONSE, "application/json"),
+                    .set_body_raw(test_vectors::ALLOCATIONS_QUERY_RESPONSE, "application/json"),
             );
 
         mock_server.register(mock).await;
@@ -484,89 +356,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(allocations.len(), 4);
-
-        assert_eq!(
-            allocations[2],
-            Allocation {
-                id: Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap(),
-                indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
-                allocated_tokens: U256::from_str("5247998688000000081956387").unwrap(),
-                created_at_block_hash:
-                    "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887".to_string(),
-                created_at_epoch: 940,
-                closed_at_epoch: Some(953),
-                subgraph_deployment: SubgraphDeployment {
-                    id: SubgraphDeploymentID::new(
-                        "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
-                    )
-                    .unwrap(),
-                    denied_at: Some(0),
-                    staked_tokens: U256::from_str("96183284152000000014901161").unwrap(),
-                    signalled_tokens: U256::from_str("182832939554154667498047").unwrap(),
-                    query_fees_amount: U256::from_str("19861336072168874330350").unwrap(),
-                },
-                status: AllocationStatus::Null,
-                closed_at_epoch_start_block_hash: None,
-                previous_epoch_start_block_hash: None,
-                poi: None,
-                query_fee_rebates: None,
-                query_fees_collected: None
-            }
-        );
-    }
-
-    #[test(tokio::test)]
-    async fn test_update_attestation_signers() {
-        let indexer_address = Address::from_str(INDEXER_ADDRESS).unwrap();
-
-        let mock_server = MockServer::start().await;
-
-        let network_subgraph_endpoint =
-            NetworkSubgraph::local_deployment_endpoint(&mock_server.uri(), NETWORK_SUBGRAPH_ID);
-        let network_subgraph = NetworkSubgraph::new(
-            Some(&mock_server.uri()),
-            Some(NETWORK_SUBGRAPH_ID),
-            network_subgraph_endpoint.as_ref(),
-        );
-
-        let mock = Mock::given(method("POST"))
-            .and(path("/subgraphs/id/".to_string() + NETWORK_SUBGRAPH_ID))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_raw(ALLOCATIONS_QUERY_RESPONSE, "application/json"),
-            );
-
-        mock_server.register(mock).await;
-
-        let inner = Arc::new(AllocationMonitorInner {
-            network_subgraph: network_subgraph.clone(),
-            indexer_address,
-            interval_ms: 1000,
-            graph_network_id: 1,
-            eligible_allocations: Arc::new(RwLock::new(Vec::new())),
-            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
-            indexer_mnemonic: INDEXER_OPERATOR_MNEMONIC.to_string(),
-            chain_id: U256::from(1),
-            dispute_manager: Address::from_str(DISPUTE_MANAGER_ADDRESS).unwrap(),
-        });
-
-        *(inner.eligible_allocations.write().await) =
-            AllocationMonitor::current_eligible_allocations(
-                &network_subgraph,
-                &indexer_address,
-                940,
-            )
-            .await
-            .unwrap();
-
-        AllocationMonitor::update_attestation_signers(&inner).await;
-
-        // Check that the attestation signers were found for the allocations
-        assert_eq!(
-            inner.attestation_signers.read().await.len(),
-            inner.eligible_allocations.read().await.len()
-        );
+        assert_eq!(allocations, test_vectors::expected_eligible_allocations())
     }
 
     /// Run with RUST_LOG=info to see the logs from the allocation monitor
@@ -579,7 +369,8 @@ mod tests {
             std::env::var("NETWORK_SUBGRAPH_ID").expect("NETWORK_SUBGRAPH_ID not set");
         let indexer_address = std::env::var("INDEXER_ADDRESS").expect("INDEXER_ADDRESS not set");
         // If you don't specify the correct mnemonic, the attestation signers won't be found
-        let indexer_mnemonic = std::env::var("INDEXER_MNEMONIC").expect("INDEXER_MNEMONIC not set");
+        let _indexer_mnemonic =
+            std::env::var("INDEXER_MNEMONIC").expect("INDEXER_MNEMONIC not set");
 
         let network_subgraph_endpoint =
             NetworkSubgraph::local_deployment_endpoint(&graph_node_url, &network_subgraph_id);
@@ -595,9 +386,6 @@ mod tests {
             Address::from_str(&indexer_address).unwrap(),
             1,
             1000,
-            indexer_mnemonic,
-            U256::from(1),
-            Address::from_str(DISPUTE_MANAGER_ADDRESS).unwrap(),
         )
         .await
         .unwrap();

--- a/service/src/allocation_monitor.rs
+++ b/service/src/allocation_monitor.rs
@@ -368,9 +368,6 @@ mod tests {
         let network_subgraph_id =
             std::env::var("NETWORK_SUBGRAPH_ID").expect("NETWORK_SUBGRAPH_ID not set");
         let indexer_address = std::env::var("INDEXER_ADDRESS").expect("INDEXER_ADDRESS not set");
-        // If you don't specify the correct mnemonic, the attestation signers won't be found
-        let _indexer_mnemonic =
-            std::env::var("INDEXER_MNEMONIC").expect("INDEXER_MNEMONIC not set");
 
         let network_subgraph_endpoint =
             NetworkSubgraph::local_deployment_endpoint(&graph_node_url, &network_subgraph_id);

--- a/service/src/attestation_signers.rs
+++ b/service/src/attestation_signers.rs
@@ -1,0 +1,162 @@
+// Copyright 2023-, GraphOps and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+use ethereum_types::{Address, U256};
+use log::{error, info, warn};
+use native::attestation::AttestationSigner;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::{
+    allocation_monitor::AllocationMonitor, common::allocation::allocation_signer,
+    util::create_attestation_signer,
+};
+
+#[derive(Debug, Clone)]
+pub struct AttestationSigners {
+    inner: Arc<AttestationSignersInner>,
+    _update_loop_handle: Arc<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Debug)]
+struct AttestationSignersInner {
+    attestation_signers: Arc<RwLock<HashMap<Address, AttestationSigner>>>,
+    allocation_monitor: AllocationMonitor,
+    indexer_mnemonic: String,
+    chain_id: U256,
+    dispute_manager: Address,
+}
+
+impl AttestationSigners {
+    pub fn new(
+        allocation_monitor: AllocationMonitor,
+        indexer_mnemonic: String,
+        chain_id: U256,
+        dispute_manager: Address,
+    ) -> Self {
+        let inner = Arc::new(AttestationSignersInner {
+            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
+            allocation_monitor,
+            indexer_mnemonic,
+            chain_id,
+            dispute_manager,
+        });
+
+        let _update_loop_handle = {
+            let inner = inner.clone();
+            tokio::spawn(Self::update_loop(inner.clone()))
+        };
+
+        Self {
+            inner,
+            _update_loop_handle: Arc::new(_update_loop_handle),
+        }
+    }
+
+    async fn update_attestation_signers(inner: Arc<AttestationSignersInner>) {
+        let mut attestation_signers_write = inner.attestation_signers.write().await;
+        for allocation in inner
+            .allocation_monitor
+            .get_eligible_allocations()
+            .await
+            .iter()
+        {
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                attestation_signers_write.entry(allocation.id)
+            {
+                match allocation_signer(&inner.indexer_mnemonic, allocation).and_then(|signer| {
+                    create_attestation_signer(
+                        inner.chain_id,
+                        inner.dispute_manager,
+                        signer,
+                        allocation.subgraph_deployment.id.bytes32(),
+                    )
+                }) {
+                    Ok(signer) => {
+                        e.insert(signer);
+                        info!(
+                            "Found attestation signer for {{allocation: {}, deployment: {}}}",
+                            allocation.id,
+                            allocation.subgraph_deployment.id.ipfs_hash()
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                        "Failed to find the attestation signer for {{allocation: {}, deployment: {}, createdAtEpoch: {}, err: {}}}",
+                        allocation.id, allocation.subgraph_deployment.id.ipfs_hash(), allocation.created_at_epoch, e
+                    )
+                    }
+                }
+            }
+        }
+    }
+
+    async fn update_loop(inner: Arc<AttestationSignersInner>) {
+        let mut watch_receiver = inner.allocation_monitor.subscribe();
+
+        loop {
+            match watch_receiver.changed().await {
+                Ok(_) => {
+                    Self::update_attestation_signers(inner.clone()).await;
+                }
+                Err(e) => {
+                    error!(
+                        "Error receiving allocation monitor subscription update: {}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    pub async fn read(
+        &self,
+    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<Address, AttestationSigner>> {
+        self.inner.attestation_signers.read().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use test_log::test;
+
+    use crate::test_vectors;
+
+    use super::*;
+
+    #[test(tokio::test)]
+    async fn test_update_attestation_signers() {
+        unsafe {
+            let mut mock_allocation_monitor = AllocationMonitor::faux();
+
+            faux::when!(mock_allocation_monitor.get_eligible_allocations).then_unchecked(|_| {
+                // Spawn a thread to be able to call `blocking_read` on the RwLock, which actually spins its own async
+                // runtime.
+                // This is needed because `faux` will also use a runtime to mock the async function.
+                let t = std::thread::spawn(|| {
+                    let eligible_allocations = Box::leak(Box::new(Arc::new(RwLock::new(
+                        test_vectors::expected_eligible_allocations(),
+                    ))));
+                    eligible_allocations.blocking_read()
+                });
+                t.join().unwrap()
+            });
+
+            let inner = Arc::new(AttestationSignersInner {
+                attestation_signers: Arc::new(RwLock::new(HashMap::new())),
+                allocation_monitor: mock_allocation_monitor,
+                indexer_mnemonic: test_vectors::INDEXER_OPERATOR_MNEMONIC.to_string(),
+                chain_id: U256::from(1),
+                dispute_manager: Address::from_str(test_vectors::DISPUTE_MANAGER_ADDRESS).unwrap(),
+            });
+
+            AttestationSigners::update_attestation_signers(inner.clone()).await;
+
+            // Check that the attestation signers were found for the allocations
+            assert_eq!(inner.attestation_signers.read().await.len(), 4);
+        }
+    }
+}

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -7,7 +7,7 @@ use native::attestation::AttestationSigner;
 use serde::{Deserialize, Serialize};
 use tap_core::tap_manager::SignedReceipt;
 
-use crate::allocation_monitor::AllocationMonitor;
+use crate::attestation_signers::AttestationSigners;
 use crate::common::types::SubgraphDeploymentID;
 use crate::graph_node::GraphNodeInstance;
 
@@ -62,17 +62,17 @@ pub enum QueryError {
 #[derive(Debug, Clone)]
 pub struct QueryProcessor {
     graph_node: GraphNodeInstance,
-    allocation_monitor: AllocationMonitor,
+    attestation_signers: AttestationSigners,
 }
 
 impl QueryProcessor {
     pub fn new(
         graph_node: GraphNodeInstance,
-        allocation_monitor: AllocationMonitor,
+        attestation_signers: AttestationSigners,
     ) -> QueryProcessor {
         QueryProcessor {
             graph_node,
-            allocation_monitor,
+            attestation_signers,
         }
     }
 
@@ -109,7 +109,7 @@ impl QueryProcessor {
 
         // TODO: Handle the TAP receipt
 
-        let signers = self.allocation_monitor.get_attestation_signers().await;
+        let signers = self.attestation_signers.read().await;
         let signer = signers.get(&allocation_id).ok_or_else(|| {
             QueryError::Other(anyhow::anyhow!(
                 "No signer found for allocation id {}",

--- a/service/src/test_vectors.rs
+++ b/service/src/test_vectors.rs
@@ -1,0 +1,215 @@
+// Copyright 2023-, GraphOps and Semiotic Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use ethereum_types::{Address, U256};
+
+use crate::common::{
+    allocation::{Allocation, AllocationStatus, SubgraphDeployment},
+    types::SubgraphDeploymentID,
+};
+
+pub const INDEXER_OPERATOR_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+pub const INDEXER_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
+pub const NETWORK_SUBGRAPH_ID: &str = "QmU7zqJyHSyUP3yFii8sBtHT8FaJn2WmUnRvwjAUTjwMBP";
+pub const DISPUTE_MANAGER_ADDRESS: &str = "0xdeadbeefcafebabedeadbeefcafebabedeadbeef";
+
+/// The allocation IDs below are generated using the mnemonic
+/// "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+/// and the following epoch and index:
+///
+/// - (createdAtEpoch, 0)
+/// - (createdAtEpoch-1, 0)
+/// - (createdAtEpoch, 2)
+/// - (createdAtEpoch-1, 1)
+///
+/// Using https://github.com/graphprotocol/indexer/blob/f8786c979a8ed0fae93202e499f5ce25773af473/packages/indexer-common/src/allocations/keys.ts#L41-L71
+pub const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
+    {
+        "data": {
+            "indexer": {
+                "activeAllocations": [
+                    {
+                        "id": "0xfa44c72b753a66591f241c7dc04e8178c30e13af",
+                        "indexer": {
+                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                        },
+                        "allocatedTokens": "5081382841000000014901161",
+                        "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
+                        "createdAtEpoch": 953,
+                        "closedAtEpoch": null,
+                        "subgraphDeployment": {
+                            "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                            "deniedAt": 0,
+                            "stakedTokens": "96183284152000000014901161",
+                            "signalledTokens": "182832939554154667498047",
+                            "queryFeesAmount": "19861336072168874330350"
+                        }
+                    },
+                    {
+                        "id": "0xdd975e30aafebb143e54d215db8a3e8fd916a701",
+                        "indexer": {
+                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                        },
+                        "allocatedTokens": "601726452999999979510903",
+                        "createdAtBlockHash": "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf",
+                        "createdAtEpoch": 953,
+                        "closedAtEpoch": null,
+                        "subgraphDeployment": {
+                            "id": "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
+                            "deniedAt": 0,
+                            "stakedTokens": "53885041676589999979510903",
+                            "signalledTokens": "104257136417832003117925",
+                            "queryFeesAmount": "2229358609434396563687"
+                        }
+                    }
+                ],
+                "recentlyClosedAllocations": [
+                    {
+                        "id": "0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658",
+                        "indexer": {
+                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                        },
+                        "allocatedTokens": "5247998688000000081956387",
+                        "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
+                        "createdAtEpoch": 940,
+                        "closedAtEpoch": 953,
+                        "subgraphDeployment": {
+                            "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                            "deniedAt": 0,
+                            "stakedTokens": "96183284152000000014901161",
+                            "signalledTokens": "182832939554154667498047",
+                            "queryFeesAmount": "19861336072168874330350"
+                        }
+                    },
+                    {
+                        "id": "0x69f961358846fdb64b04e1fd7b2701237c13cd9a",
+                        "indexer": {
+                            "id": "0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c"
+                        },
+                        "allocatedTokens": "2502334654999999795109034",
+                        "createdAtBlockHash": "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887",
+                        "createdAtEpoch": 940,
+                        "closedAtEpoch": 953,
+                        "subgraphDeployment": {
+                            "id": "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
+                            "deniedAt": 0,
+                            "stakedTokens": "85450761241000000055879354",
+                            "signalledTokens": "154944508746646550301048",
+                            "queryFeesAmount": "4293718622418791971020"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+"#;
+
+/// These are the expected json-serialized contents of the value returned by
+/// AllocationMonitor::current_eligible_allocations with the values above at epoch threshold 940.
+pub fn expected_eligible_allocations() -> Vec<Allocation> {
+    vec![
+        Allocation {
+            id: Address::from_str("0xfa44c72b753a66591f241c7dc04e8178c30e13af").unwrap(),
+            indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
+            allocated_tokens: U256::from_str("5081382841000000014901161").unwrap(),
+            created_at_block_hash:
+                "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf".to_string(),
+            created_at_epoch: 953,
+            closed_at_epoch: None,
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                )
+                .unwrap(),
+                denied_at: Some(0),
+                staked_tokens: U256::from_str("96183284152000000014901161").unwrap(),
+                signalled_tokens: U256::from_str("182832939554154667498047").unwrap(),
+                query_fees_amount: U256::from_str("19861336072168874330350").unwrap(),
+            },
+            status: AllocationStatus::Null,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        },
+        Allocation {
+            id: Address::from_str("0xdd975e30aafebb143e54d215db8a3e8fd916a701").unwrap(),
+            indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
+            allocated_tokens: U256::from_str("601726452999999979510903").unwrap(),
+            created_at_block_hash:
+                "0x99d3fbdc0105f7ccc0cd5bb287b82657fe92db4ea8fb58242dafb90b1c6e2adf".to_string(),
+            created_at_epoch: 953,
+            closed_at_epoch: None,
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
+                )
+                .unwrap(),
+                denied_at: Some(0),
+                staked_tokens: U256::from_str("53885041676589999979510903").unwrap(),
+                signalled_tokens: U256::from_str("104257136417832003117925").unwrap(),
+                query_fees_amount: U256::from_str("2229358609434396563687").unwrap(),
+            },
+            status: AllocationStatus::Null,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        },
+        Allocation {
+            id: Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap(),
+            indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
+            allocated_tokens: U256::from_str("5247998688000000081956387").unwrap(),
+            created_at_block_hash:
+                "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887".to_string(),
+            created_at_epoch: 940,
+            closed_at_epoch: Some(953),
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
+                )
+                .unwrap(),
+                denied_at: Some(0),
+                staked_tokens: U256::from_str("96183284152000000014901161").unwrap(),
+                signalled_tokens: U256::from_str("182832939554154667498047").unwrap(),
+                query_fees_amount: U256::from_str("19861336072168874330350").unwrap(),
+            },
+            status: AllocationStatus::Null,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        },
+        Allocation {
+            id: Address::from_str("0x69f961358846fdb64b04e1fd7b2701237c13cd9a").unwrap(),
+            indexer: Address::from_str("0xd75c4dbcb215a6cf9097cfbcc70aab2596b96a9c").unwrap(),
+            allocated_tokens: U256::from_str("2502334654999999795109034").unwrap(),
+            created_at_block_hash:
+                "0x6e7b7100c37f659236a029f87ce18914643995120f55ab5d01631f11f40fd887".to_string(),
+            created_at_epoch: 940,
+            closed_at_epoch: Some(953),
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new(
+                    "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
+                )
+                .unwrap(),
+                denied_at: Some(0),
+                staked_tokens: U256::from_str("85450761241000000055879354").unwrap(),
+                signalled_tokens: U256::from_str("154944508746646550301048").unwrap(),
+                query_fees_amount: U256::from_str("4293718622418791971020").unwrap(),
+            },
+            status: AllocationStatus::Null,
+            closed_at_epoch_start_block_hash: None,
+            previous_epoch_start_block_hash: None,
+            poi: None,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        },
+    ]
+}


### PR DESCRIPTION
Now can subscribe to `AllocationMonitor` updates, so `AttestationSigners` knows when to update its signers list. Makes way for TAP to also watch the `AllocationMonitor`.

Note: Moved some test vectors out of allocation_monitor.rs to share them amongst test files.

Fixes #41