### PR TITLE
Refactor to use eventuals for monitoring network data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "by_address"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1919,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eventuals"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0450e5c57135f799007162ff8beba7b2809d4a018cf9cdcbca2c319a73d9d8ee"
+dependencies = [
+ "by_address",
+ "futures",
+ "never",
+ "tokio",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2002,12 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "firestorm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5f6c2c942da57e2aaaa84b8a521489486f14e75e7fa91dab70aba913975f98"
 
 [[package]]
 name = "fixed-hash"
@@ -2676,16 +2700,19 @@ dependencies = [
  "ethereum-types",
  "ethers",
  "ethers-core",
+ "eventuals",
  "faux",
  "keccak-hash",
  "lazy_static",
  "log",
+ "lru",
  "reqwest",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "test-log",
  "tokio",
+ "toolshed",
  "wiremock",
 ]
 
@@ -2708,6 +2735,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2989,6 +3017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+dependencies = [
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3204,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4696,6 +4739,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "service"
 version = "0.1.0"
 dependencies = [
@@ -4720,6 +4792,7 @@ dependencies = [
  "ethers",
  "ethers-contract",
  "ethers-core",
+ "eventuals",
  "faux",
  "graphql-parser",
  "hex",
@@ -5628,6 +5701,21 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "toolshed"
+version = "0.2.2"
+source = "git+https://github.com/edgeandnode/toolshed?tag=v0.2.2#5daca78935d9a9fc34216946d3f22c614d9dbeee"
+dependencies = [
+ "alloy-primitives",
+ "bs58 0.5.0",
+ "firestorm",
+ "graphql-parser",
+ "serde",
+ "serde_with",
+ "sha3",
+ "url",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,15 +12,18 @@ eip-712-derive = { git = "https://github.com/graphprotocol/eip-712-derive" }
 ethereum-types = "0.14.1"
 ethers = "2.0.10"
 ethers-core = "2.0.10"
+eventuals = "0.6.7"
 faux = { version = "0.1.10", optional = true }
 keccak-hash = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.20"
+lru = "0.11.1"
 reqwest = "0.11.20"
 secp256k1 = { version = "0.27.0", features = ["recovery"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1.32.0", features = ["full", "macros", "rt"] }
+toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.2", features = ["graphql"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/common/src/allocations/mod.rs
+++ b/common/src/allocations/mod.rs
@@ -2,19 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use alloy_primitives::Address;
-use anyhow::Result;
-use ethers::signers::coins_bip39::English;
-use ethers::signers::{MnemonicBuilder, Signer, Wallet};
-use ethers_core::k256::ecdsa::SigningKey;
 use ethers_core::types::U256;
-use serde::Deserialize;
-use serde::Deserializer;
+use serde::{Deserialize, Deserializer};
 
 use crate::types::SubgraphDeploymentID;
 
 pub mod monitor;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Allocation {
     pub id: Address,
     pub status: AllocationStatus,
@@ -31,7 +26,7 @@ pub struct Allocation {
     pub query_fees_collected: Option<U256>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AllocationStatus {
     Null,
     Active,
@@ -40,7 +35,7 @@ pub enum AllocationStatus {
     Claimed,
 }
 
-#[derive(Debug, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct SubgraphDeployment {
     pub id: SubgraphDeploymentID,
     #[serde(rename = "deniedAt")]
@@ -92,173 +87,5 @@ impl<'d> Deserialize<'d> for Allocation {
             query_fee_rebates: None,
             query_fees_collected: None,
         })
-    }
-}
-
-pub fn derive_key_pair(
-    indexer_mnemonic: &str,
-    epoch: u64,
-    deployment: &SubgraphDeploymentID,
-    index: u64,
-) -> Result<Wallet<SigningKey>> {
-    let mut derivation_path = format!("m/{}/", epoch);
-    derivation_path.push_str(
-        &deployment
-            .ipfs_hash()
-            .as_bytes()
-            .iter()
-            .map(|char| char.to_string())
-            .collect::<Vec<String>>()
-            .join("/"),
-    );
-    derivation_path.push_str(format!("/{}", index).as_str());
-
-    Ok(MnemonicBuilder::<English>::default()
-        .derivation_path(&derivation_path)
-        .expect("Valid derivation path")
-        .phrase(indexer_mnemonic)
-        .build()?)
-}
-
-pub fn allocation_signer(indexer_mnemonic: &str, allocation: &Allocation) -> Result<SigningKey> {
-    // Guess the allocation index by enumerating all indexes in the
-    // range [0, 100] and checking for a match
-    for i in 0..100 {
-        // The allocation was either created at the epoch it intended to or one
-        // epoch later. So try both both.
-        for created_at_epoch in [allocation.created_at_epoch, allocation.created_at_epoch - 1] {
-            let allocation_wallet = derive_key_pair(
-                indexer_mnemonic,
-                created_at_epoch,
-                &allocation.subgraph_deployment.id,
-                i,
-            )?;
-            if allocation_wallet.address().as_fixed_bytes() == allocation.id {
-                return Ok(allocation_wallet.signer().clone());
-            }
-        }
-    }
-    Err(anyhow::anyhow!(
-        "Could not find allocation signer for allocation {}",
-        allocation.id
-    ))
-}
-
-#[cfg(test)]
-mod test {
-    use std::str::FromStr;
-
-    use crate::prelude::SubgraphDeploymentID;
-
-    use super::*;
-
-    const INDEXER_OPERATOR_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-
-    #[test]
-    fn test_derive_key_pair() {
-        assert_eq!(
-            derive_key_pair(
-                INDEXER_OPERATOR_MNEMONIC,
-                953,
-                &SubgraphDeploymentID::new(
-                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
-                )
-                .unwrap(),
-                0
-            )
-            .unwrap()
-            .address()
-            .as_fixed_bytes(),
-            Address::from_str("0xfa44c72b753a66591f241c7dc04e8178c30e13af").unwrap()
-        );
-
-        assert_eq!(
-            derive_key_pair(
-                INDEXER_OPERATOR_MNEMONIC,
-                940,
-                &SubgraphDeploymentID::new(
-                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a"
-                )
-                .unwrap(),
-                2
-            )
-            .unwrap()
-            .address()
-            .as_fixed_bytes(),
-            Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap()
-        );
-    }
-
-    #[test]
-    fn test_allocation_signer() {
-        // Note that we use `derive_key_pair` to derive the private key
-
-        let allocation = Allocation {
-            id: Address::from_str("0xa171cd12c3dde7eb8fe7717a0bcd06f3ffa65658").unwrap(),
-            status: AllocationStatus::Null,
-            subgraph_deployment: SubgraphDeployment {
-                id: SubgraphDeploymentID::new(
-                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                )
-                .unwrap(),
-                denied_at: None,
-                staked_tokens: U256::zero(),
-                signalled_tokens: U256::zero(),
-                query_fees_amount: U256::zero(),
-            },
-            indexer: Address::ZERO,
-            allocated_tokens: U256::zero(),
-            created_at_epoch: 940,
-            created_at_block_hash: "".to_string(),
-            closed_at_epoch: None,
-            closed_at_epoch_start_block_hash: None,
-            previous_epoch_start_block_hash: None,
-            poi: None,
-            query_fee_rebates: None,
-            query_fees_collected: None,
-        };
-        assert_eq!(
-            allocation_signer(INDEXER_OPERATOR_MNEMONIC, &allocation).unwrap(),
-            *derive_key_pair(
-                INDEXER_OPERATOR_MNEMONIC,
-                940,
-                &allocation.subgraph_deployment.id,
-                2
-            )
-            .unwrap()
-            .signer()
-        );
-    }
-
-    #[test]
-    fn test_allocation_signer_error() {
-        // Note that because allocation will try 200 derivations paths, this is a slow test
-
-        let allocation = Allocation {
-            // Purposefully wrong address
-            id: Address::from_str("0xdeadbeefcafebabedeadbeefcafebabedeadbeef").unwrap(),
-            status: AllocationStatus::Null,
-            subgraph_deployment: SubgraphDeployment {
-                id: SubgraphDeploymentID::new(
-                    "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                )
-                .unwrap(),
-                denied_at: None,
-                staked_tokens: U256::zero(),
-                signalled_tokens: U256::zero(),
-                query_fees_amount: U256::zero(),
-            },
-            indexer: Address::ZERO,
-            allocated_tokens: U256::zero(),
-            created_at_epoch: 940,
-            created_at_block_hash: "".to_string(),
-            closed_at_epoch: None,
-            closed_at_epoch_start_block_hash: None,
-            previous_epoch_start_block_hash: None,
-            poi: None,
-            query_fee_rebates: None,
-            query_fees_collected: None,
-        };
-        assert!(allocation_signer(INDEXER_OPERATOR_MNEMONIC, &allocation).is_err());
     }
 }

--- a/common/src/attestations/signer.rs
+++ b/common/src/attestations/signer.rs
@@ -5,15 +5,20 @@ use alloy_primitives::Address;
 use eip_712_derive::{
     sign_typed, Bytes32, DomainSeparator, Eip712Domain, MemberVisitor, StructType,
 };
-use ethers::utils::hex;
+use ethers::{
+    signers::{coins_bip39::English, MnemonicBuilder, Signer, Wallet},
+    utils::hex,
+};
 use ethers_core::k256::ecdsa::SigningKey;
 use ethers_core::types::U256;
 use keccak_hash::keccak;
 use secp256k1::SecretKey;
 use std::convert::TryInto;
 
+use crate::prelude::{Allocation, SubgraphDeploymentID};
+
 /// An attestation signer tied to a specific allocation via its signer key
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttestationSigner {
     subgraph_deployment_id: Bytes32,
     domain_separator: DomainSeparator,
@@ -22,30 +27,35 @@ pub struct AttestationSigner {
 
 impl AttestationSigner {
     pub fn new(
-        chain_id: eip_712_derive::U256,
+        indexer_mnemonic: &str,
+        allocation: &Allocation,
+        chain_id: U256,
         dispute_manager: Address,
-        signer: SecretKey,
-        subgraph_deployment_id: Bytes32,
-    ) -> Self {
+    ) -> Result<Self, anyhow::Error> {
+        // Recreate a wallet that has the same address as the allocation
+        let wallet = wallet_for_allocation(indexer_mnemonic, allocation)?;
+
+        // Convert chain ID into EIP-712 representation
+        let mut chain_id_bytes = [0u8; 32];
+        chain_id.to_big_endian(&mut chain_id_bytes);
+        let chain_id = eip_712_derive::U256(chain_id_bytes);
+
         let bytes = hex::decode("a070ffb1cd7409649bf77822cce74495468e06dbfaef09556838bf188679b9c2")
             .unwrap();
 
         let salt: [u8; 32] = bytes.try_into().unwrap();
 
-        let domain = Eip712Domain {
-            name: "Graph Protocol".to_owned(),
-            version: "0".to_owned(),
-            chain_id,
-            verifying_contract: eip_712_derive::Address(dispute_manager.into()),
-            salt,
-        };
-        let domain_separator = DomainSeparator::new(&domain);
-
-        Self {
-            domain_separator,
-            signer,
-            subgraph_deployment_id,
-        }
+        Ok(Self {
+            domain_separator: DomainSeparator::new(&Eip712Domain {
+                name: "Graph Protocol".to_owned(),
+                version: "0".to_owned(),
+                chain_id,
+                verifying_contract: eip_712_derive::Address(dispute_manager.into()),
+                salt,
+            }),
+            signer: SecretKey::from_slice(&wallet.signer().to_bytes())?,
+            subgraph_deployment_id: allocation.subgraph_deployment.id.bytes32(),
+        })
     }
 
     pub fn create_attestation(&self, request: &str, response: &str) -> Attestation {
@@ -101,21 +111,58 @@ pub struct Attestation {
     pub s: Bytes32,
 }
 
-/// Helper for creating an AttestationSigner
-pub fn create_attestation_signer(
-    chain_id: U256,
-    dispute_manager_address: Address,
-    signer: SigningKey,
-    deployment_id: [u8; 32],
-) -> anyhow::Result<AttestationSigner> {
-    // Tedious conversions to the "indexer_native" types
-    let mut chain_id_bytes = [0u8; 32];
-    chain_id.to_big_endian(&mut chain_id_bytes);
-    let signer = AttestationSigner::new(
-        eip_712_derive::U256(chain_id_bytes),
-        dispute_manager_address,
-        secp256k1::SecretKey::from_slice(&signer.to_bytes())?,
-        deployment_id,
+fn derive_key_pair(
+    indexer_mnemonic: &str,
+    epoch: u64,
+    deployment: &SubgraphDeploymentID,
+    index: u64,
+) -> Result<Wallet<SigningKey>, anyhow::Error> {
+    let mut derivation_path = format!("m/{}/", epoch);
+    derivation_path.push_str(
+        &deployment
+            .ipfs_hash()
+            .as_bytes()
+            .iter()
+            .map(|char| char.to_string())
+            .collect::<Vec<String>>()
+            .join("/"),
     );
-    Ok(signer)
+    derivation_path.push_str(format!("/{}", index).as_str());
+
+    Ok(MnemonicBuilder::<English>::default()
+        .derivation_path(&derivation_path)
+        .expect("Valid derivation path")
+        .phrase(indexer_mnemonic)
+        .build()?)
+}
+
+fn wallet_for_allocation(
+    indexer_mnemonic: &str,
+    allocation: &Allocation,
+) -> Result<Wallet<SigningKey>, anyhow::Error> {
+    // Guess the allocation index by enumerating all indexes in the
+    // range [0, 100] and checking for a match
+    for i in 0..100 {
+        // The allocation was either created at the epoch it intended to or one
+        // epoch later. So try both both.
+        for created_at_epoch in [allocation.created_at_epoch, allocation.created_at_epoch - 1] {
+            // The allocation ID is the address of a unique key pair, we just
+            // need to find the right one by enumerating them all
+            let wallet = derive_key_pair(
+                indexer_mnemonic,
+                created_at_epoch,
+                &allocation.subgraph_deployment.id,
+                i,
+            )?;
+
+            // See if we have a match, i.e. a wallet whose address is identical to the allocation ID
+            if wallet.address().as_fixed_bytes() == allocation.id {
+                return Ok(wallet);
+            }
+        }
+    }
+    Err(anyhow::anyhow!(
+        "Could not generate wallet matching allocation {}",
+        allocation.id
+    ))
 }

--- a/common/src/attestations/signers.rs
+++ b/common/src/attestations/signers.rs
@@ -3,162 +3,53 @@
 
 use alloy_primitives::Address;
 use ethers_core::types::U256;
-use log::{error, info, warn};
-use std::collections::HashMap;
+use eventuals::{Eventual, EventualExt};
+use log::warn;
+use lru::LruCache;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::{collections::HashMap, num::NonZeroUsize};
+use tokio::sync::Mutex;
 
-use crate::prelude::{AllocationMonitor, AttestationSigner};
+use crate::prelude::{Allocation, AttestationSigner};
 
-use super::{attestation_signer_for_allocation, signer::create_attestation_signer};
-
-#[derive(Debug, Clone)]
-pub struct AttestationSigners {
-    inner: Arc<AttestationSignersInner>,
-    _update_loop_handle: Arc<tokio::task::JoinHandle<()>>,
-}
-
-#[derive(Debug)]
-pub struct AttestationSignersInner {
-    attestation_signers: Arc<RwLock<HashMap<Address, AttestationSigner>>>,
-    allocation_monitor: AllocationMonitor,
+/// An always up-to-date list of attestation signers, one for each of the indexer's allocations.
+pub fn attestation_signers(
+    indexer_allocations: Eventual<HashMap<Address, Allocation>>,
     indexer_mnemonic: String,
     chain_id: U256,
     dispute_manager: Address,
-}
+) -> Eventual<HashMap<Address, AttestationSigner>> {
+    // Keep a cache of the most recent 1000 signers around so we don't need to recreate them
+    // every time there is a small change in the allocations
+    let cache: &'static Mutex<LruCache<_, _>> = Box::leak(Box::new(Mutex::new(LruCache::new(
+        NonZeroUsize::new(1000).unwrap(),
+    ))));
 
-impl AttestationSigners {
-    pub fn new(
-        allocation_monitor: AllocationMonitor,
-        indexer_mnemonic: String,
-        chain_id: U256,
-        dispute_manager: Address,
-    ) -> Self {
-        let inner = Arc::new(AttestationSignersInner {
-            attestation_signers: Arc::new(RwLock::new(HashMap::new())),
-            allocation_monitor,
-            indexer_mnemonic,
-            chain_id,
-            dispute_manager,
-        });
+    let indexer_mnemonic = Arc::new(indexer_mnemonic);
 
-        let _update_loop_handle = {
-            let inner = inner.clone();
-            tokio::spawn(Self::update_loop(inner.clone()))
-        };
+    // Whenever the indexer's active or recently closed allocations change, make sure
+    // we have attestation signers for all of them
+    indexer_allocations.map(move |allocations| {
+        let indexer_mnemonic = indexer_mnemonic.clone();
 
-        Self {
-            inner,
-            _update_loop_handle: Arc::new(_update_loop_handle),
-        }
-    }
+        async move {
+            let mut cache = cache.lock().await;
 
-    pub async fn update_attestation_signers(inner: Arc<AttestationSignersInner>) {
-        let mut attestation_signers_write = inner.attestation_signers.write().await;
-        for allocation in inner
-            .allocation_monitor
-            .get_eligible_allocations()
-            .await
-            .values()
-        {
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                attestation_signers_write.entry(allocation.id)
-            {
-                match attestation_signer_for_allocation(&inner.indexer_mnemonic, allocation)
-                    .and_then(|signer| {
-                        create_attestation_signer(
-                            inner.chain_id,
-                            inner.dispute_manager,
-                            signer,
-                            allocation.subgraph_deployment.id.bytes32(),
-                        )
-                    }) {
-                    Ok(signer) => {
-                        e.insert(signer);
-                        info!(
-                            "Found attestation signer for {{allocation: {}, deployment: {}}}",
-                            allocation.id,
-                            allocation.subgraph_deployment.id.ipfs_hash()
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                        "Failed to find the attestation signer for {{allocation: {}, deployment: {}, createdAtEpoch: {}, err: {}}}",
-                        allocation.id, allocation.subgraph_deployment.id.ipfs_hash(), allocation.created_at_epoch, e
-                    )
-                    }
-                }
-            }
-        }
-    }
+            for (id, allocation) in allocations.iter() {
+                let result = cache.try_get_or_insert(*id, || {
+                    AttestationSigner::new(&indexer_mnemonic, allocation, chain_id, dispute_manager)
+                });
 
-    async fn update_loop(inner: Arc<AttestationSignersInner>) {
-        let mut watch_receiver = inner.allocation_monitor.subscribe();
-
-        loop {
-            match watch_receiver.changed().await {
-                Ok(_) => {
-                    Self::update_attestation_signers(inner.clone()).await;
-                }
-                Err(e) => {
-                    error!(
-                        "Error receiving allocation monitor subscription update: {}",
-                        e
+                if let Err(e) = result {
+                    warn!(
+                        "Failed to establish signer for allocation {}, deployment {}, createdAtEpoch {}: {}",
+                        allocation.id, allocation.subgraph_deployment.id.ipfs_hash(),
+                        allocation.created_at_epoch, e
                     );
                 }
             }
+
+            HashMap::from_iter(cache.iter().map(|(k, v)| (*k, v.clone())))
         }
-    }
-
-    pub async fn read(
-        &self,
-    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<Address, AttestationSigner>> {
-        self.inner.attestation_signers.read().await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy_primitives::Address;
-    use ethers_core::types::U256;
-    use std::str::FromStr;
-    use std::sync::Arc;
-
-    use crate::prelude::AllocationMonitor;
-    use crate::test_vectors;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_update_attestation_signers() {
-        unsafe {
-            let mut mock_allocation_monitor = AllocationMonitor::faux();
-
-            faux::when!(mock_allocation_monitor.get_eligible_allocations).then_unchecked(|_| {
-                // Spawn a thread to be able to call `blocking_read` on the RwLock, which actually spins its own async
-                // runtime.
-                // This is needed because `faux` will also use a runtime to mock the async function.
-                let t = std::thread::spawn(|| {
-                    let eligible_allocations = Box::leak(Box::new(Arc::new(RwLock::new(
-                        test_vectors::expected_eligible_allocations(),
-                    ))));
-                    eligible_allocations.blocking_read()
-                });
-                t.join().unwrap()
-            });
-
-            let inner = Arc::new(AttestationSignersInner {
-                attestation_signers: Arc::new(RwLock::new(HashMap::new())),
-                allocation_monitor: mock_allocation_monitor,
-                indexer_mnemonic: test_vectors::INDEXER_OPERATOR_MNEMONIC.to_string(),
-                chain_id: U256::from(1),
-                dispute_manager: Address::from_str(test_vectors::DISPUTE_MANAGER_ADDRESS).unwrap(),
-            });
-
-            AttestationSigners::update_attestation_signers(inner.clone()).await;
-
-            // Check that the attestation signers were found for the allocations
-            assert_eq!(inner.attestation_signers.read().await.len(), 4);
-        }
-    }
+    })
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,13 +11,9 @@ pub mod types;
 mod test_vectors;
 
 pub mod prelude {
-    pub use super::allocations::monitor::AllocationMonitor;
+    pub use super::allocations::monitor::indexer_allocations;
     pub use super::allocations::{Allocation, AllocationStatus, SubgraphDeployment};
-    pub use super::attestations::{
-        attestation_signer_for_allocation,
-        signer::{create_attestation_signer, AttestationSigner},
-        signers::AttestationSigners,
-    };
+    pub use super::attestations::{signer::AttestationSigner, signers::attestation_signers};
     pub use super::network_subgraph::NetworkSubgraph;
     pub use super::types::*;
 }

--- a/common/src/network_subgraph/mod.rs
+++ b/common/src/network_subgraph/mod.rs
@@ -4,16 +4,9 @@
 use std::sync::Arc;
 
 use reqwest::{header, Client, Url};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
-
-use crate::types::GraphQLQuery;
-
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct Response<T> {
-    pub result: T,
-    pub status: i64,
-}
+use toolshed::graphql::http::Response;
 
 /// Network subgraph query wrapper
 ///
@@ -60,36 +53,25 @@ impl NetworkSubgraph {
             .expect("Could not parse graph node query endpoint for the network subgraph deployment")
     }
 
-    pub async fn network_query_raw(
+    pub async fn query<T: for<'de> Deserialize<'de>>(
         &self,
-        body: String,
-    ) -> Result<reqwest::Response, reqwest::Error> {
+        body: &Value,
+    ) -> Result<Response<T>, reqwest::Error> {
         self.client
             .post(Url::clone(&self.network_subgraph_url))
-            .body(body.clone())
+            .json(body)
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await
-    }
-
-    pub async fn network_query(
-        &self,
-        query: String,
-        variables: Option<Value>,
-    ) -> Result<Value, reqwest::Error> {
-        let body = GraphQLQuery { query, variables };
-
-        self.network_query_raw(
-            serde_json::to_string(&body).expect("serialize network GraphQL query"),
-        )
-        .await?
-        .json::<Value>()
-        .await
+            .and_then(|response| response.error_for_status())?
+            .json::<Response<T>>()
+            .await
     }
 }
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -138,7 +120,7 @@ mod test {
 
         // Check that the response is valid JSON
         network_subgraph
-            .network_query(query.to_string(), None)
+            .query::<Value>(&json!({ "query": query }))
             .await
             .unwrap();
     }
@@ -159,7 +141,7 @@ mod test {
 
         // Check that the response is valid JSON
         network_subgraph
-            .network_query(query.to_string(), None)
+            .query::<Value>(&json!({ "query": query }))
             .await
             .unwrap();
     }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -2,16 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use ethers::utils::hex;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
-/// A serializable GraphQL request
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GraphQLQuery {
-    pub query: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub variables: Option<Value>,
-}
+use serde::Deserialize;
 
 /// Subgraph identifier type: SubgraphDeploymentID with field 'value'
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -60,6 +60,7 @@ ethereum-types = "0.14.1"
 sqlx = { version = "0.7.1", features = ["postgres", "runtime-tokio", "bigdecimal", "rust_decimal", "time"] }
 alloy-primitives = { version = "0.3.3", features = ["serde"] }
 alloy-sol-types = "0.3.2"
+eventuals = "0.6.7"
 
 [dev-dependencies]
 faux = "0.1.10"

--- a/service/src/server/mod.rs
+++ b/service/src/server/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub mod routes;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ServerOptions {
     pub port: Option<u32>,
     pub release: PackageVersion,
@@ -38,7 +38,7 @@ pub struct ServerOptions {
     pub graph_node_status_endpoint: String,
     pub indexer_management_db: PgPool,
     pub operator_public_key: String,
-    pub network_subgraph: NetworkSubgraph,
+    pub network_subgraph: &'static NetworkSubgraph,
     pub network_subgraph_auth_token: Option<String>,
     pub serve_network_subgraph: bool,
 }
@@ -53,7 +53,7 @@ impl ServerOptions {
         graph_node_status_endpoint: String,
         indexer_management_db: PgPool,
         operator_public_key: String,
-        network_subgraph: NetworkSubgraph,
+        network_subgraph: &'static NetworkSubgraph,
         network_subgraph_auth_token: Option<String>,
         serve_network_subgraph: bool,
     ) -> Self {

--- a/service/src/tap_manager.rs
+++ b/service/src/tap_manager.rs
@@ -1,19 +1,20 @@
 // Copyright 2023-, GraphOps and Semiotic Labs.
 // SPDX-License-Identifier: Apache-2.0
 
+use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
+use eventuals::Eventual;
+use indexer_common::prelude::Allocation;
 use log::error;
 use sqlx::{types::BigDecimal, PgPool};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tap_core::tap_manager::SignedReceipt;
-
-use indexer_common::prelude::AllocationMonitor;
 
 use crate::{escrow_monitor, query_processor::QueryError};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct TapManager {
-    allocation_monitor: AllocationMonitor,
+    indexer_allocations: Eventual<HashMap<Address, Allocation>>,
     escrow_monitor: escrow_monitor::EscrowMonitor,
     pgpool: PgPool,
     domain_separator: Arc<Eip712Domain>,
@@ -22,12 +23,12 @@ pub struct TapManager {
 impl TapManager {
     pub fn new(
         pgpool: PgPool,
-        allocation_monitor: AllocationMonitor,
+        indexer_allocations: Eventual<HashMap<Address, Allocation>>,
         escrow_monitor: escrow_monitor::EscrowMonitor,
         domain_separator: Eip712Domain,
     ) -> Self {
         Self {
-            allocation_monitor,
+            indexer_allocations,
             escrow_monitor,
             pgpool,
             domain_separator: Arc::new(domain_separator),
@@ -43,9 +44,11 @@ impl TapManager {
     pub async fn verify_and_store_receipt(&self, receipt: SignedReceipt) -> Result<(), QueryError> {
         let allocation_id = &receipt.message.allocation_id;
         if !self
-            .allocation_monitor
-            .is_allocation_eligible(allocation_id)
+            .indexer_allocations
+            .value()
             .await
+            .map(|allocations| allocations.contains_key(allocation_id))
+            .unwrap_or(false)
         {
             return Err(QueryError::Other(anyhow::Error::msg(format!(
                 "Receipt's allocation ID ({}) is not eligible for this indexer",
@@ -100,13 +103,14 @@ mod test {
 
     use alloy_primitives::Address;
     use alloy_sol_types::{eip712_domain, Eip712Domain};
+    use ethereum_types::{H256, U256};
     use ethers::signers::{coins_bip39::English, LocalWallet, MnemonicBuilder, Signer};
+    use indexer_common::prelude::{AllocationStatus, SubgraphDeployment};
+    use indexer_common::types::SubgraphDeploymentID;
     use sqlx::postgres::PgListener;
 
     use tap_core::tap_manager::SignedReceipt;
     use tap_core::{eip_712_signed_message::EIP712SignedMessage, tap_receipt::Receipt};
-
-    use indexer_common::prelude::AllocationMonitor;
 
     use super::*;
 
@@ -170,9 +174,32 @@ mod test {
         let signed_receipt =
             create_signed_receipt(allocation_id, u64::MAX, u64::MAX, u128::MAX).await;
 
-        // Mock allocation monitor
-        let mut mock_allocation_monitor = AllocationMonitor::faux();
-        faux::when!(mock_allocation_monitor.is_allocation_eligible).then_return(true);
+        // Mock allocation
+        let allocation = Allocation {
+            id: allocation_id,
+            subgraph_deployment: SubgraphDeployment {
+                id: SubgraphDeploymentID::new("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                    .unwrap(),
+                denied_at: None,
+                query_fees_amount: U256::zero(),
+                signalled_tokens: U256::zero(),
+                staked_tokens: U256::zero(),
+            },
+            status: AllocationStatus::Active,
+            allocated_tokens: U256::zero(),
+            closed_at_epoch: None,
+            closed_at_epoch_start_block_hash: None,
+            poi: None,
+            previous_epoch_start_block_hash: None,
+            created_at_block_hash: H256::zero().to_string(),
+            created_at_epoch: 0,
+            indexer: Address::ZERO,
+            query_fee_rebates: None,
+            query_fees_collected: None,
+        };
+        let indexer_allocations = Eventual::from_value(HashMap::from_iter(
+            vec![(allocation_id, allocation)].into_iter(),
+        ));
 
         // Mock escrow monitor
         let mut mock_escrow_monitor = escrow_monitor::EscrowMonitor::faux();
@@ -180,7 +207,7 @@ mod test {
 
         let tap_manager = TapManager::new(
             pgpool.clone(),
-            mock_allocation_monitor,
+            indexer_allocations,
             mock_escrow_monitor,
             domain,
         );


### PR DESCRIPTION
Eventuals are like `tokio::sync::watch`, except they only trigger an update downstream if their value changes, not every time a new value is written into it. It's a nice primitive to ensure we always have the latest value available and only do something when there are changes.

This switches to eventuals for the following things:
- Monitoring the indexer's own allocations. This outputs an update to date list of active and recently closed allocations and updates every 30s.
- Creating attestation signers. This takes the indexer's allocations and ensures that we can always sign attestations for queries made against the subgraphs that were allocated to.