### PR TITLE
fix: remove irrelevant fields from deployment queries

### DIFF
--- a/common/src/allocations/mod.rs
+++ b/common/src/allocations/mod.rs
@@ -39,12 +39,6 @@ pub struct SubgraphDeployment {
     pub id: DeploymentId,
     #[serde(rename = "deniedAt")]
     pub denied_at: Option<u64>,
-    #[serde(rename = "stakedTokens")]
-    pub staked_tokens: U256,
-    #[serde(rename = "signalledTokens")]
-    pub signalled_tokens: U256,
-    #[serde(rename = "queryFeesAmount")]
-    pub query_fees_amount: U256,
 }
 
 impl<'d> Deserialize<'d> for Allocation {

--- a/common/src/allocations/monitor.rs
+++ b/common/src/allocations/monitor.rs
@@ -100,9 +100,6 @@ pub fn indexer_allocations(
                     subgraphDeployment {
                         id
                         deniedAt
-                        stakedTokens
-                        signalledTokens
-                        queryFeesAmount
                     }
                 }
                 recentlyClosedAllocations: totalAllocations(
@@ -121,9 +118,6 @@ pub fn indexer_allocations(
                     subgraphDeployment {
                         id
                         deniedAt
-                        stakedTokens
-                        signalledTokens
-                        queryFeesAmount
                     }
                 }
             }

--- a/common/src/attestations/signer.rs
+++ b/common/src/attestations/signer.rs
@@ -187,9 +187,6 @@ mod tests {
                 )
                 .unwrap(),
                 denied_at: None,
-                staked_tokens: U256::zero(),
-                signalled_tokens: U256::zero(),
-                query_fees_amount: U256::zero(),
             },
             indexer: Address::ZERO,
             allocated_tokens: U256::zero(),
@@ -236,9 +233,6 @@ mod tests {
                 )
                 .unwrap(),
                 denied_at: None,
-                staked_tokens: U256::zero(),
-                signalled_tokens: U256::zero(),
-                query_fees_amount: U256::zero(),
             },
             indexer: Address::ZERO,
             allocated_tokens: U256::zero(),

--- a/common/src/test_vectors.rs
+++ b/common/src/test_vectors.rs
@@ -36,10 +36,7 @@ pub const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
                         "closedAtEpoch": null,
                         "subgraphDeployment": {
                             "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                            "deniedAt": 0,
-                            "stakedTokens": "96183284152000000014901161",
-                            "signalledTokens": "182832939554154667498047",
-                            "queryFeesAmount": "19861336072168874330350"
+                            "deniedAt": 0
                         }
                     },
                     {
@@ -53,10 +50,7 @@ pub const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
                         "closedAtEpoch": null,
                         "subgraphDeployment": {
                             "id": "0xcda7fa0405d6fd10721ed13d18823d24b535060d8ff661f862b26c23334f13bf",
-                            "deniedAt": 0,
-                            "stakedTokens": "53885041676589999979510903",
-                            "signalledTokens": "104257136417832003117925",
-                            "queryFeesAmount": "2229358609434396563687"
+                            "deniedAt": 0
                         }
                     }
                 ],
@@ -72,10 +66,7 @@ pub const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
                         "closedAtEpoch": 953,
                         "subgraphDeployment": {
                             "id": "0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e66502ab0076b7218f98a",
-                            "deniedAt": 0,
-                            "stakedTokens": "96183284152000000014901161",
-                            "signalledTokens": "182832939554154667498047",
-                            "queryFeesAmount": "19861336072168874330350"
+                            "deniedAt": 0
                         }
                     },
                     {
@@ -89,10 +80,7 @@ pub const ALLOCATIONS_QUERY_RESPONSE: &str = r#"
                         "closedAtEpoch": 953,
                         "subgraphDeployment": {
                             "id": "0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425f68ed4c74964ae705cbd",
-                            "deniedAt": 0,
-                            "stakedTokens": "85450761241000000055879354",
-                            "signalledTokens": "154944508746646550301048",
-                            "queryFeesAmount": "4293718622418791971020"
+                            "deniedAt": 0
                         }
                     }
                 ]
@@ -134,9 +122,6 @@ lazy_static! {
                             .unwrap(),
                     ),
                     denied_at: Some(0),
-                    staked_tokens: U256::from_str("96183284152000000014901161").unwrap(),
-                    signalled_tokens: U256::from_str("182832939554154667498047").unwrap(),
-                    query_fees_amount: U256::from_str("19861336072168874330350").unwrap(),
                 },
                 status: AllocationStatus::Null,
                 closed_at_epoch_start_block_hash: None,
@@ -163,9 +148,6 @@ lazy_static! {
                             .unwrap(),
                     ),
                     denied_at: Some(0),
-                    staked_tokens: U256::from_str("53885041676589999979510903").unwrap(),
-                    signalled_tokens: U256::from_str("104257136417832003117925").unwrap(),
-                    query_fees_amount: U256::from_str("2229358609434396563687").unwrap(),
                 },
                 status: AllocationStatus::Null,
                 closed_at_epoch_start_block_hash: None,
@@ -192,9 +174,6 @@ lazy_static! {
                             .unwrap(),
                     ),
                     denied_at: Some(0),
-                    staked_tokens: U256::from_str("96183284152000000014901161").unwrap(),
-                    signalled_tokens: U256::from_str("182832939554154667498047").unwrap(),
-                    query_fees_amount: U256::from_str("19861336072168874330350").unwrap(),
                 },
                 status: AllocationStatus::Null,
                 closed_at_epoch_start_block_hash: None,
@@ -221,9 +200,6 @@ lazy_static! {
                             .unwrap(),
                     ),
                     denied_at: Some(0),
-                    staked_tokens: U256::from_str("85450761241000000055879354").unwrap(),
-                    signalled_tokens: U256::from_str("154944508746646550301048").unwrap(),
-                    query_fees_amount: U256::from_str("4293718622418791971020").unwrap(),
                 },
                 status: AllocationStatus::Null,
                 closed_at_epoch_start_block_hash: None,

--- a/service/src/query_processor.rs
+++ b/service/src/query_processor.rs
@@ -186,9 +186,6 @@ mod tests {
         let subgraph_deployment = SubgraphDeployment {
             id: *DEPLOYMENT_ID,
             denied_at: None,
-            staked_tokens: U256::from(0),
-            signalled_tokens: U256::from(0),
-            query_fees_amount: U256::from(0),
         };
 
         let indexer = Address::from_str(INDEXER_ADDRESS).unwrap();

--- a/service/src/tap_manager.rs
+++ b/service/src/tap_manager.rs
@@ -180,9 +180,6 @@ mod test {
             subgraph_deployment: SubgraphDeployment {
                 id: DeploymentId::from_str("QmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap(),
                 denied_at: None,
-                query_fees_amount: U256::zero(),
-                signalled_tokens: U256::zero(),
-                staked_tokens: U256::zero(),
             },
             status: AllocationStatus::Active,
             allocated_tokens: U256::zero(),


### PR DESCRIPTION
We may need to add these back later for other purposes, but indexer-service does not need these fields; the only reason it queries allocations is to create attestation signers for them.

There might be even more fields that we could remove. However, signalled_tokens in particular is necessary at the moment because there is buggy data in the real-world network subgraph where the field is negative sometimes. That breaks U256 parsing. Since we don't need this and the other fields, I thought it best to remove them.