### PR TITLE
fix(service): ms intervals treated as seconds

### DIFF
--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), std::io::Error> {
         network_subgraph,
         config.ethereum.indexer_address,
         1,
-        Duration::from_secs(config.network_subgraph.allocation_syncing_interval),
+        Duration::from_millis(config.network_subgraph.allocation_syncing_interval),
     );
 
     // TODO: Chain ID should be a config
@@ -118,7 +118,7 @@ async fn main() -> Result<(), std::io::Error> {
     let escrow_accounts = escrow_accounts(
         escrow_subgraph,
         config.ethereum.indexer_address,
-        Duration::from_secs(config.escrow_subgraph.escrow_syncing_interval),
+        Duration::from_millis(config.escrow_subgraph.escrow_syncing_interval),
     );
 
     let tap_manager = TapManager::new(


### PR DESCRIPTION
Because the indexer-service arguments are asking for ms:
https://github.com/graphops/indexer-service-rs/blob/b603c306969e1a202ea15381438cde3a5204dcc3/service/src/config.rs#L211-L218
https://github.com/graphops/indexer-service-rs/blob/b603c306969e1a202ea15381438cde3a5204dcc3/service/src/config.rs#L260-L267
(I'll fix clap for this second one later)

This is carried from the original `indexer-service`. Even though asking for seconds directly may make more sense, that would introduce a breaking change for users.