### PR TITLE
fix: add config for receipts domain

### DIFF
--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -20,6 +20,8 @@ pub struct Cli {
     #[command(flatten)]
     pub ethereum: Ethereum,
     #[command(flatten)]
+    pub receipts: Receipts,
+    #[command(flatten)]
     pub indexer_infrastructure: IndexerInfrastructure,
     #[command(flatten)]
     pub postgres: Postgres,
@@ -69,6 +71,25 @@ pub struct Ethereum {
         help = "Ethereum address of the indexer"
     )]
     pub indexer_address: Address,
+}
+
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
+#[group(required = true, multiple = true)]
+pub struct Receipts {
+    #[clap(
+        long,
+        value_name = "receipts-verifier-chain-id",
+        env = "RECEIPTS_VERIFIER_CHAIN_ID",
+        help = "Scalar TAP verifier chain ID"
+    )]
+    pub receipts_verifier_chain_id: u64,
+    #[clap(
+        long,
+        value_name = "receipts-verifier-address",
+        env = "RECEIPTS_VERIFIER_ADDRESS",
+        help = "Scalar TAP verifier contract address"
+    )]
+    pub receipts_verifier_address: Address,
 }
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -127,12 +127,12 @@ async fn main() -> Result<(), std::io::Error> {
         escrow_accounts,
         // TODO: arguments for eip712_domain should be a config
         eip712_domain! {
-            name: "TapManager",
+            name: "Scalar TAP",
             version: "1",
-            verifying_contract: config.ethereum.indexer_address,
+            chain_id: config.receipts.receipts_verifier_chain_id,
+            verifying_contract: config.receipts.receipts_verifier_address,
         },
     );
-
     // Proper initiation of server, query processor
     // server health check, graph-node instance connection check
     let query_processor =


### PR DESCRIPTION
This adds the config options, `chain_id` & `verifying_contract`, required to contruct the EIP-712 domain used when verifying receipts.